### PR TITLE
[APP / Audio] Add more Audio Channels

### DIFF
--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -34,6 +34,8 @@ export enum E_AUDIO_CHANNELS {
   INPUT_1 = 3,
   INPUT_2 = 4,
   INPUT_3 = 5,
+  INPUT_4 = 6,
+  INPUT_5 = 7,
 }
 
 interface IAudioSourceData {

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -355,7 +355,7 @@ export class SettingsService extends StatefulService<ISettingsServiceState> {
     }
 
     // collect input channels info
-    for (let channel = E_AUDIO_CHANNELS.INPUT_1; channel <= E_AUDIO_CHANNELS.INPUT_3; channel++) {
+    for (let channel = E_AUDIO_CHANNELS.INPUT_1; channel <= E_AUDIO_CHANNELS.INPUT_5; channel++) {
       const source = sourcesInChannels.find(source => source.channel === channel);
       const deviceInd = channel - 2;
 


### PR DESCRIPTION
I added some more audio channels. In the base there are 2 output and 3 input. Here we have the example with Voicemeter Banana and Virtual Audio cable where you can add more channels to the system and handle all these extra channels by Slabs.