### PR TITLE
fix for safe mode api issue

### DIFF
--- a/app/services/recent-events.ts
+++ b/app/services/recent-events.ts
@@ -952,17 +952,18 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
   }
 
   updateSafeModeSettingsFromServer(data: ISafeModeServerSettings) {
+    const sm = this.state.safeMode;
     this.SET_SAFE_MODE_SETTINGS({
-      clearChat: data.clear_chat,
-      clearQueuedAlerts: data.clear_queued_alerts,
-      clearRecentEvents: data.clear_recent_events,
-      disableChatAlerts: data.disable_chat_alerts,
-      disableFollowerAlerts: data.disable_follower_alerts,
-      emoteOnly: data.emote_only,
-      followerOnly: data.follower_only,
-      subOnly: data.sub_only,
-      enableTimer: data.enable_timer,
-      timeInMinutes: data.time_in_minutes,
+      clearChat: data.clear_chat ? data.clear_chat : sm.clearChat,
+      clearQueuedAlerts: data.clear_queued_alerts ? data.clear_queued_alerts : sm.clearQueuedAlerts,
+      clearRecentEvents: data.clear_recent_events ? data.clear_recent_events : sm.clearRecentEvents,
+      disableChatAlerts: data.disable_chat_alerts ? data.disable_chat_alerts : sm.disableChatAlerts,
+      disableFollowerAlerts: data.disable_follower_alerts ? data.disable_follower_alerts : sm.disableFollowerAlerts,
+      emoteOnly: data.emote_only ? data.emote_only : sm.emoteOnly,
+      followerOnly: data.follower_only ? data.follower_only : sm.followerOnly,
+      subOnly: data.sub_only ? data.sub_only : sm.subOnly,
+      enableTimer: data.enable_timer ? data.enable_timer : sm.enableTimer,
+      timeInMinutes: data.time_in_minutes ? data.time_in_minutes : sm.timeInMinutes,
     });
   }
 

--- a/app/services/recent-events.ts
+++ b/app/services/recent-events.ts
@@ -442,9 +442,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
   fetchRecentEvents() {
     const typeString = this.getEventTypesString();
     // eslint-disable-next-line
-    const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/recentevents/${
-      this.userService.widgetToken
-    }?types=${typeString}`;
+    const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/recentevents/${this.userService.widgetToken}?types=${typeString}`;
     const headers = authorizedHeaders(this.userService.apiToken);
     const request = new Request(url, { headers });
     return jfetch<{ data: Dictionary<IRecentEvent[]> }>(request).catch(() => {
@@ -454,9 +452,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
 
   async fetchConfig() {
     // eslint-disable-next-line
-    const url = `https://${
-      this.hostsService.streamlabs
-    }/api/v5/slobs/widget/config?widget=recent_events`;
+    const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/widget/config?widget=recent_events`;
     const headers = authorizedHeaders(this.userService.apiToken);
     return jfetch<IRecentEventsConfig>(url, { headers }).catch(() => {
       console.warn('Error fetching recent events config');
@@ -465,9 +461,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
 
   fetchMediaShareState() {
     // eslint-disable-next-line
-    const url = `https://${
-      this.hostsService.streamlabs
-    }/api/v5/slobs/widget/config?widget=media-sharing`;
+    const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/widget/config?widget=media-sharing`;
     const headers = authorizedHeaders(this.userService.apiToken);
     return jfetch<{ settings: { advanced_settings: { enabled: boolean } } }>(url, {
       headers,
@@ -884,9 +878,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
       new Headers({ 'Content-Type': 'application/json' }),
     );
     // eslint-disable-next-line
-    const url = `https://${
-      this.hostsService.streamlabs
-    }/api/v5/slobs/widget/recentevents/eventspanel`;
+    const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/widget/recentevents/eventspanel`;
     const body = JSON.stringify({ muted: !this.state.muted });
     return await fetch(new Request(url, { headers, body, method: 'POST' })).then(handleResponse);
   }
@@ -958,7 +950,9 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
       clearQueuedAlerts: data.clear_queued_alerts ? data.clear_queued_alerts : sm.clearQueuedAlerts,
       clearRecentEvents: data.clear_recent_events ? data.clear_recent_events : sm.clearRecentEvents,
       disableChatAlerts: data.disable_chat_alerts ? data.disable_chat_alerts : sm.disableChatAlerts,
-      disableFollowerAlerts: data.disable_follower_alerts ? data.disable_follower_alerts : sm.disableFollowerAlerts,
+      disableFollowerAlerts: data.disable_follower_alerts
+        ? data.disable_follower_alerts
+        : sm.disableFollowerAlerts,
       emoteOnly: data.emote_only ? data.emote_only : sm.emoteOnly,
       followerOnly: data.follower_only ? data.follower_only : sm.followerOnly,
       subOnly: data.sub_only ? data.sub_only : sm.subOnly,

--- a/app/services/recent-events.ts
+++ b/app/services/recent-events.ts
@@ -441,7 +441,6 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
 
   fetchRecentEvents() {
     const typeString = this.getEventTypesString();
-    // eslint-disable-next-line
     const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/recentevents/${this.userService.widgetToken}?types=${typeString}`;
     const headers = authorizedHeaders(this.userService.apiToken);
     const request = new Request(url, { headers });
@@ -451,7 +450,6 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
   }
 
   async fetchConfig() {
-    // eslint-disable-next-line
     const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/widget/config?widget=recent_events`;
     const headers = authorizedHeaders(this.userService.apiToken);
     return jfetch<IRecentEventsConfig>(url, { headers }).catch(() => {
@@ -460,7 +458,6 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
   }
 
   fetchMediaShareState() {
-    // eslint-disable-next-line
     const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/widget/config?widget=media-sharing`;
     const headers = authorizedHeaders(this.userService.apiToken);
     return jfetch<{ settings: { advanced_settings: { enabled: boolean } } }>(url, {
@@ -877,7 +874,6 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
       this.userService.apiToken,
       new Headers({ 'Content-Type': 'application/json' }),
     );
-    // eslint-disable-next-line
     const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/widget/recentevents/eventspanel`;
     const body = JSON.stringify({ muted: !this.state.muted });
     return await fetch(new Request(url, { headers, body, method: 'POST' })).then(handleResponse);
@@ -946,18 +942,16 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
   updateSafeModeSettingsFromServer(data: ISafeModeServerSettings) {
     const sm = this.state.safeMode;
     this.SET_SAFE_MODE_SETTINGS({
-      clearChat: data.clear_chat ? data.clear_chat : sm.clearChat,
-      clearQueuedAlerts: data.clear_queued_alerts ? data.clear_queued_alerts : sm.clearQueuedAlerts,
-      clearRecentEvents: data.clear_recent_events ? data.clear_recent_events : sm.clearRecentEvents,
-      disableChatAlerts: data.disable_chat_alerts ? data.disable_chat_alerts : sm.disableChatAlerts,
-      disableFollowerAlerts: data.disable_follower_alerts
-        ? data.disable_follower_alerts
-        : sm.disableFollowerAlerts,
-      emoteOnly: data.emote_only ? data.emote_only : sm.emoteOnly,
-      followerOnly: data.follower_only ? data.follower_only : sm.followerOnly,
-      subOnly: data.sub_only ? data.sub_only : sm.subOnly,
-      enableTimer: data.enable_timer ? data.enable_timer : sm.enableTimer,
-      timeInMinutes: data.time_in_minutes ? data.time_in_minutes : sm.timeInMinutes,
+      clearChat: data.clear_chat ?? sm.clearChat,
+      clearQueuedAlerts: data.clear_queued_alerts ?? sm.clearQueuedAlerts,
+      clearRecentEvents: data.clear_recent_events ?? sm.clearRecentEvents,
+      disableChatAlerts: data.disable_chat_alerts ?? sm.disableChatAlerts,
+      disableFollowerAlerts: data.disable_follower_alerts ?? sm.disableFollowerAlerts,
+      emoteOnly: data.emote_only ?? sm.emoteOnly,
+      followerOnly: data.follower_only ?? sm.followerOnly,
+      subOnly: data.sub_only ?? sm.subOnly,
+      enableTimer: data.enable_timer ?? sm.enableTimer,
+      timeInMinutes: data.time_in_minutes ?? sm.timeInMinutes,
     });
   }
 


### PR DESCRIPTION
not sure if/how/when this broke but when we fetch a user's Safe Mode settings via API, it doesn't return all required fields, so if the user tries to activate Safe Mode without changing any settings, it fails because we're not sending all required fields. 

my proposed fix will set each setting to whatever is in state if it isn't defined via the API fetch, that way if/when the API is fixed to actually return all required values, it won't break anything in our app