### PR TITLE
correct comparison for default variation.id

### DIFF
--- a/app/components/widgets/AlertBox.vue
+++ b/app/components/widgets/AlertBox.vue
@@ -87,12 +87,12 @@
             </div>
             <div class="variation-tile__toolbar">
               <i
-                v-if="variation.id.indexOf('default')"
+                v-if="variation.id.indexOf('default') === -1"
                 class="icon-trash"
                 @click.stop="removeVariation(variation.id)"
               />
               <i
-                v-if="variation.id.indexOf('default')"
+                v-if="variation.id.indexOf('default') === -1"
                 class="icon-edit"
                 @click.stop="editName(variation.id)"
               />

--- a/app/components/widgets/AlertBox.vue
+++ b/app/components/widgets/AlertBox.vue
@@ -87,12 +87,12 @@
             </div>
             <div class="variation-tile__toolbar">
               <i
-                v-if="variation.id.indexOf('default') === -1"
+                v-if="!variation.id.includes('default')"
                 class="icon-trash"
                 @click.stop="removeVariation(variation.id)"
               />
               <i
-                v-if="variation.id.indexOf('default') === -1"
+                v-if="!variation.id.includes('default')"
                 class="icon-edit"
                 @click.stop="editName(variation.id)"
               />

--- a/app/components/widgets/AlertBox.vue
+++ b/app/components/widgets/AlertBox.vue
@@ -87,12 +87,12 @@
             </div>
             <div class="variation-tile__toolbar">
               <i
-                v-if="variation.id !== 'default'"
+                v-if="variation.id.indexOf('default')"
                 class="icon-trash"
                 @click.stop="removeVariation(variation.id)"
               />
               <i
-                v-if="variation.id !== 'default'"
+                v-if="variation.id.indexOf('default')"
                 class="icon-edit"
                 @click.stop="editName(variation.id)"
               />


### PR DESCRIPTION
at some point, the API started returning default variations as some form of `default-follows`, `default-subs`, etc, instead of just `default` which is what we were checking for. 

this change checks if the id contains `default`, so that we're not showing delete and rename buttons for default variations, as they cannot be deleted or renamed. 