### PR TITLE
fix persistent "downloading" toast message

### DIFF
--- a/app/components/windows/MediaGallery.vue.ts
+++ b/app/components/windows/MediaGallery.vue.ts
@@ -237,7 +237,7 @@ export default class MediaGallery extends Vue {
       defaultPath: this.selectedFile.filename,
     });
 
-    if (!this.selectedFile) return;
+    if (!filePath) return;
     this.setBusy($t('Downloading...'));
     await this.mediaGalleryService.downloadFile(filePath, this.selectedFile);
     this.setNotBusy();


### PR DESCRIPTION
had an issue where if you clicked the download button, then hit "cancel" on the file path prompt, you'd be stuck with a yellow "Downloading" message in child windows until you closed and relaunched the app. 