### PR TITLE
protect against unsupported transition types

### DIFF
--- a/app/services/obs-importer.ts
+++ b/app/services/obs-importer.ts
@@ -423,7 +423,10 @@ export class ObsImporterService extends StatefulService<{ progress: number; tota
       configJSON.transitions &&
       configJSON.transitions.length > 0 &&
       // only import if it's a supported transition type
-      this.transitionsService.views.getTypes().map(t => t.value).includes(configJSON.transitions[0].id as ETransitionType)
+      this.transitionsService.views
+        .getTypes()
+        .map(t => t.value)
+        .includes(configJSON.transitions[0].id as ETransitionType)
     ) {
       this.transitionsService.deleteAllTransitions();
       this.transitionsService.createTransition(

--- a/app/services/obs-importer.ts
+++ b/app/services/obs-importer.ts
@@ -419,7 +419,11 @@ export class ObsImporterService extends StatefulService<{ progress: number; tota
   importTransitions(configJSON: IOBSConfigJSON) {
     // Only import a single transition from OBS for now.
     // Eventually we should import all transitions
-    if (configJSON.transitions && configJSON.transitions.length > 0) {
+    if (
+      configJSON.transitions &&
+      configJSON.transitions.length > 0 &&
+      Object.values<string>(ETransitionType).includes(configJSON.transitions[0].id)
+    ) {
       this.transitionsService.deleteAllTransitions();
       this.transitionsService.createTransition(
         configJSON.transitions[0].id as ETransitionType,

--- a/app/services/obs-importer.ts
+++ b/app/services/obs-importer.ts
@@ -423,7 +423,7 @@ export class ObsImporterService extends StatefulService<{ progress: number; tota
       configJSON.transitions &&
       configJSON.transitions.length > 0 &&
       // only import if it's a supported transition type
-      Object.values<string>(ETransitionType).includes(configJSON.transitions[0].id)
+      this.transitionsService.views.getTypes().map(t => t.value).includes(configJSON.transitions[0].id as ETransitionType)
     ) {
       this.transitionsService.deleteAllTransitions();
       this.transitionsService.createTransition(

--- a/app/services/obs-importer.ts
+++ b/app/services/obs-importer.ts
@@ -422,6 +422,7 @@ export class ObsImporterService extends StatefulService<{ progress: number; tota
     if (
       configJSON.transitions &&
       configJSON.transitions.length > 0 &&
+      // only import if it's a supported transition type
       Object.values<string>(ETransitionType).includes(configJSON.transitions[0].id)
     ) {
       this.transitionsService.deleteAllTransitions();


### PR DESCRIPTION
while investigating a user report, discovered that during obs import we don't handle unsupported transition types gracefully. added a protection so that if a user is using an unsupported transition type (like, added via plugin), we skip transition import to avoid breaking the user's scene collection