### PR TITLE
add goaltype back to subgoal

### DIFF
--- a/app/components/widgets/goal/SubGoal.tsx
+++ b/app/components/widgets/goal/SubGoal.tsx
@@ -5,6 +5,6 @@ import Vue from 'vue';
 @Component({})
 export default class SubGoal extends Vue {
   render() {
-    return <GenericGoal />;
+    return <GenericGoal goalType="sub" />;
   }
 }


### PR DESCRIPTION
in [this PR](https://github.com/stream-labs/desktop/pull/3190), the Sub Goal lost it's goalType prop during refactoring, causing the "include resubs" option to no longer show up in widget settings