### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/app/components/shared/inputs/FormInput.vue.ts
+++ b/app/components/shared/inputs/FormInput.vue.ts
@@ -33,7 +33,7 @@ export default class FormInput extends BaseInput<any, IInputMetadata> {
     const type = this.options.type;
 
     // tslint:disable-next-line:prefer-template
-    return type.charAt(0).toUpperCase() + type.substr(1) + 'Input';
+    return type.charAt(0).toUpperCase() + type.slice(1) + 'Input';
   }
 
   getOptions() {

--- a/app/services-manager.ts
+++ b/app/services-manager.ts
@@ -100,7 +100,7 @@ export class ServicesManager extends Service {
     }
 
     const helperName = resourceId.split('[')[0];
-    const constructorArgsStr = resourceId.substr(helperName.length);
+    const constructorArgsStr = resourceId.slice(helperName.length);
     const constructorArgs = constructorArgsStr ? JSON.parse(constructorArgsStr) : void 0;
     return this.getHelper(helperName, constructorArgs);
   }

--- a/app/services/api/external-api.ts
+++ b/app/services/api/external-api.ts
@@ -105,7 +105,7 @@ export class ExternalApiService extends RpcApi {
     // if resource is not singleton
     // take serialized constructor arguments from `resourceId` string and construct a new instance
     const helperName = resourceId.split('[')[0];
-    const constructorArgsStr = resourceId.substr(helperName.length);
+    const constructorArgsStr = resourceId.slice(helperName.length);
     const constructorArgs = constructorArgsStr ? JSON.parse(constructorArgsStr) : void 0;
     const Helper = this.resources[helperName];
     if (Helper) {

--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -239,7 +239,7 @@ export class FacebookService
 
     // setup stream key and new settings
     const streamUrl = liveVideo.stream_url;
-    const streamKey = streamUrl.substr(streamUrl.lastIndexOf('/') + 1);
+    const streamKey = streamUrl.slice(streamUrl.lastIndexOf('/') + 1);
     if (!this.streamingService.views.isMultiplatformMode) {
       this.streamSettingsService.setSettings({
         key: streamKey,

--- a/test/helpers/form-monkey.ts
+++ b/test/helpers/form-monkey.ts
@@ -296,7 +296,7 @@ export class FormMonkey {
     const $colorPicker = await this.client.$(`${selector} [name="colorpicker-input"]`);
     await $colorPicker.click(); // open colorpicker
     // tslint:disable-next-line:no-parameter-reassignment TODO
-    value = value.substr(1); // get rid of # character in value
+    value = value.slice(1); // get rid of # character in value
     const inputSelector = `${selector} .vc-input__input`;
     await sleep(100); // give colorpicker some time to be opened
     await this.setInputValue(inputSelector, value);

--- a/test/helpers/scene-builder.ts
+++ b/test/helpers/scene-builder.ts
@@ -79,7 +79,7 @@ export class SceneBuilder {
     }
 
     // normalize sketch by removing spaces at the beginning of each line
-    strings = strings.map(str => str.substr(offset));
+    strings = strings.map(str => str.slice(offset));
 
     const foldersStack: ISceneBuilderNode[] = [];
     const result: ISceneBuilderNode[] = [];

--- a/test/helpers/spectron/index.ts
+++ b/test/helpers/spectron/index.ts
@@ -242,7 +242,7 @@ export function useSpectron(options: ITestRunnerOptions = {}) {
     const logs: string = await readLogs();
     lastLogs = logs;
     const errors = logs
-      .substr(logFileLastReadingPos)
+      .slice(logFileLastReadingPos)
       .split('\n')
       .filter((record: string) => {
         // This error is outside our control and can be ignored.


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.