### PR TITLE
fix capitalization of page category

### DIFF
--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -664,7 +664,7 @@ export class FacebookService
       this.state.facebookPages.find(p => p.id === this.state.settings.pageId);
 
     // determine the chat url
-    if (page && page.category === 'Gaming Video Creator') {
+    if (page && page.category === 'Gaming video creator') {
       // GVC pages have a specific chat url
       return `https://www.facebook.com/live/producer/dashboard/${this.state.videoId}/COMMENTS/`;
     } else if (page && this.state.settings.game) {


### PR DESCRIPTION
seems like FB changed the capitalization of the page.category, causing us to load the legacy chat URL for GVC pages instead of the "good" one