### PR TITLE
add mac logic for default webcam

### DIFF
--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -288,6 +288,14 @@ export class SourcesService extends StatefulService<ISourcesState> {
     ) {
       this.sourceFiltersService.addPresetFilter(id, this.defaultHardwareService.state.presetFilter);
     }
+
+    if (
+      this.defaultHardwareService.state.defaultVideoDevice === obsInputSettings.device &&
+      this.defaultHardwareService.state.presetFilter !== ''
+    ) {
+      this.sourceFiltersService.addPresetFilter(id, this.defaultHardwareService.state.presetFilter);
+    }
+
     return this.views.getSource(id)!;
   }
 
@@ -465,6 +473,14 @@ export class SourcesService extends StatefulService<ISourcesState> {
       this.defaultHardwareService.state.defaultVideoDevice
     ) {
       resolvedSettings.video_device_id = this.defaultHardwareService.state.defaultVideoDevice;
+    }
+
+    if (
+      type === 'av_capture_input' &&
+      resolvedSettings.device === void 0 &&
+      this.defaultHardwareService.state.defaultVideoDevice
+    ) {
+      resolvedSettings.device = this.defaultHardwareService.state.defaultVideoDevice;
     }
 
     // TODO: Specifically for TikTok, we don't use auto mode on game capture


### PR DESCRIPTION
Discovered while testing latest preview on Mac that we never fully set up Mac-specific logic for the "Default Hardware" feature, specifically for webcams (audio device works fine as its the same as on Windows)

Set up Mac-specific logic and it is now working correctly. I've applied the WIP label as there might be a more concise way of applying this OS-specific logic that I'm not aware of. 