### PR TITLE
Save a copy of updater command line arguments to a file

### DIFF
--- a/updater/bootstrap.ts
+++ b/updater/bootstrap.ts
@@ -369,11 +369,13 @@ async function entry(info: IUpdateInfo) {
 
   console.log('Spawning updater with args:', updaterArgs);
 
-  var arg_file = fs.createWriteStream(path.resolve(info.tempDir, 'update.cfg'));
-  arg_file.on('error', function (err) { });
+  const arg_file = fs.createWriteStream(path.resolve(info.tempDir, 'update.cfg'));
+  arg_file.on('error', function (err) {});
   const updaterArgsPath = [`"${updaterPath}"`];
-  var argumentsArray = updaterArgsPath.concat(updaterArgs);
-  argumentsArray.forEach(function (v) { arg_file.write(v.replace(/"/g, '').replace(/\\\\/g, '\\') + '\n'); });
+  const argumentsArray = updaterArgsPath.concat(updaterArgs);
+  argumentsArray.forEach(function (v) {
+    arg_file.write(v.replace(/"/g, '').replace(/\\\\/g, '\\') + '\n');
+  });
   arg_file.end();
 
   const updaterProcess = cp.spawn(updaterStartCommand, updaterArgs, {

--- a/updater/bootstrap.ts
+++ b/updater/bootstrap.ts
@@ -371,7 +371,7 @@ async function entry(info: IUpdateInfo) {
 
   const arg_file = fs.createWriteStream(path.resolve(info.tempDir, 'update.cfg'));
   arg_file.on('error', function (err) {
-    console.log('Failed to write updater argument to a file ' + path.resolve(info.tempDir, 'update.cfg'));
+    console.log('Failed to write updater argument to a file');
   });
   const updaterArgsPath = [`"${updaterPath}"`];
   const argumentsArray = updaterArgsPath.concat(updaterArgs);

--- a/updater/bootstrap.ts
+++ b/updater/bootstrap.ts
@@ -369,6 +369,13 @@ async function entry(info: IUpdateInfo) {
 
   console.log('Spawning updater with args:', updaterArgs);
 
+  var arg_file = fs.createWriteStream(path.resolve(info.tempDir, 'update.cfg'));
+  arg_file.on('error', function (err) { });
+  const updaterArgsPath = [`"${updaterPath}"`];
+  var argumentsArray = updaterArgsPath.concat(updaterArgs);
+  argumentsArray.forEach(function (v) { arg_file.write(v.replace(/"/g, '').replace(/\\\\/g, '\\') + '\n'); });
+  arg_file.end();
+
   const updaterProcess = cp.spawn(updaterStartCommand, updaterArgs, {
     cwd: info.tempDir,
     detached: true,

--- a/updater/bootstrap.ts
+++ b/updater/bootstrap.ts
@@ -370,7 +370,9 @@ async function entry(info: IUpdateInfo) {
   console.log('Spawning updater with args:', updaterArgs);
 
   const arg_file = fs.createWriteStream(path.resolve(info.tempDir, 'update.cfg'));
-  arg_file.on('error', function (err) {});
+  arg_file.on('error', function (err) {
+    console.log('Failed to write updater argument to a file ' + path.resolve(info.tempDir, 'update.cfg'));
+  });
   const updaterArgsPath = [`"${updaterPath}"`];
   const argumentsArray = updaterArgsPath.concat(updaterArgs);
   argumentsArray.forEach(function (v) {


### PR DESCRIPTION
Save a copy of updater command line arguments to a file. 
Updater will try to use it if api for command line arguments failed. 

File is not formatted. Same arguments should be put in file just line by line for each array element. 


PR for updater
https://github.com/stream-labs/a-files-updater/pull/69