### PR TITLE
Revert "Downgrade electron to 14.2.2 because of unicode issues (#4107)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "css-element-queries": "1.2.3",
     "css-loader": "2.1.1",
     "dotenv": "8.2.0",
-    "electron": "14.2.2",
+    "electron": "14.2.6",
     "electron-builder": "22.14.5",
     "electron-devtools-installer": "3.1.1",
     "electron-notarize": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6532,16 +6532,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:14.2.2":
-  version: 14.2.2
-  resolution: "electron@npm:14.2.2"
+"electron@npm:14.2.6":
+  version: 14.2.6
+  resolution: "electron@npm:14.2.6"
   dependencies:
     "@electron/get": ^1.0.1
     "@types/node": ^14.6.2
     extract-zip: ^1.0.3
   bin:
     electron: cli.js
-  checksum: c56e561f175c3016e31844d4e518ac548cc06588c52fa9e4c3dc5bccd8c6ec30cf392316c9749ef18d5d4d91daeb4513c4575a0828dfd8a7881ac465725f1e83
+  checksum: f0ce42459502f9f7d937374699eefbb56dacc03b21c7e7933f5a865c4f1f05aba00eafa3a217fa97d91559ffffe5f57ab17c2001a5e122118957932e360bb707
   languageName: node
   linkType: hard
 
@@ -14423,7 +14423,7 @@ __metadata:
     css-element-queries: 1.2.3
     css-loader: 2.1.1
     dotenv: 8.2.0
-    electron: 14.2.2
+    electron: 14.2.6
     electron-builder: 22.14.5
     electron-chromedriver: ^14.0.0
     electron-devtools-installer: 3.1.1


### PR DESCRIPTION
This reverts commit 9b673b19af47172b4617015e1a4ed7c2f38d4728.