### PR TITLE
Url protocol fixes

### DIFF
--- a/app/services/hosts.ts
+++ b/app/services/hosts.ts
@@ -48,13 +48,17 @@ export class HostsService extends Service {
 }
 
 export class UrlService extends Service {
-  @Inject('HostsService') private hosts: HostsService;
+  @Inject('HostsService') private hostsService: HostsService;
 
   get protocol() {
     return Util.shouldUseLocalHost() ? 'http://' : 'https://';
   }
 
+  get streamlabsBase() {
+    return `${this.protocol}${this.hostsService.streamlabs}`;
+  }
+
   getStreamlabsApi(endpoint: string) {
-    return `${this.protocol}${this.hosts.streamlabs}/api/v5/slobs/${endpoint}`;
+    return `${this.streamlabsBase}/api/v5/slobs/${endpoint}`;
   }
 }

--- a/app/services/platforms/twitch.ts
+++ b/app/services/platforms/twitch.ts
@@ -6,7 +6,7 @@ import {
   IPlatformState,
   TPlatformCapability,
 } from '.';
-import { HostsService } from 'services/hosts';
+import { UrlService } from 'services/hosts';
 import { Inject } from 'services/core/injector';
 import { authorizedHeaders, jfetch } from 'util/requests';
 import { UserService } from 'services/user';
@@ -70,7 +70,7 @@ interface ITwitchServiceState extends IPlatformState {
 export class TwitchService
   extends BasePlatformService<ITwitchServiceState>
   implements IPlatformService {
-  @Inject() hostsService: HostsService;
+  @Inject() urlService: UrlService;
   @Inject() userService: UserService;
   @Inject() customizationService: CustomizationService;
 
@@ -126,14 +126,13 @@ export class TwitchService
   }
 
   get authUrl() {
-    const host = this.hostsService.streamlabs;
     const scopes: TTwitchOAuthScope[] = ['channel_read', 'channel_editor', 'user:edit:broadcast'];
 
     const query =
       `_=${Date.now()}&skip_splash=true&external=electron&twitch&force_verify&` +
       `scope=${scopes.join(',')}&origin=slobs`;
 
-    return `https://${host}/slobs/login?${query}`;
+    return `${this.urlService.streamlabsBase}/slobs/login?${query}`;
   }
 
   // TODO: Refactor so this is reusable
@@ -215,8 +214,7 @@ export class TwitchService
   }
 
   fetchNewToken(): Promise<void> {
-    const host = this.hostsService.streamlabs;
-    const url = `https://${host}/api/v5/slobs/twitch/refresh`;
+    const url = this.urlService.getStreamlabsApi('twitch/refresh');
     const headers = authorizedHeaders(this.userService.apiToken!);
     const request = new Request(url, { headers });
 

--- a/app/services/recent-events.ts
+++ b/app/services/recent-events.ts
@@ -1,4 +1,4 @@
-import { HostsService } from 'services/hosts';
+import { UrlService } from 'services/hosts';
 import { StatefulService, Inject, mutation, InitAfter, ViewHandler } from 'services/core';
 import { UserService, LoginLifecycle } from 'services/user';
 import { authorizedHeaders, handleResponse, jfetch } from 'util/requests';
@@ -397,7 +397,7 @@ class RecentEventsViews extends ViewHandler<IRecentEventsState> {
 
 @InitAfter('UserService')
 export class RecentEventsService extends StatefulService<IRecentEventsState> {
-  @Inject() private hostsService: HostsService;
+  @Inject() private urlService: UrlService;
   @Inject() private userService: UserService;
   @Inject() private windowsService: WindowsService;
   @Inject() private websocketService: WebsocketService;
@@ -469,7 +469,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
   fetchRecentEvents() {
     const typeString = this.getEventTypesString();
     // eslint-disable-next-line
-    const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/recentevents/${
+    const url = `${this.urlService.streamlabsBase}/api/v5/slobs/recentevents/${
       this.userService.widgetToken
     }?types=${typeString}`;
     const headers = authorizedHeaders(this.userService.apiToken);
@@ -481,9 +481,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
 
   async fetchConfig() {
     // eslint-disable-next-line
-    const url = `https://${
-      this.hostsService.streamlabs
-    }/api/v5/slobs/widget/config?widget=recent_events`;
+    const url = `${this.urlService.streamlabsBase}/api/v5/slobs/widget/config?widget=recent_events`;
     const headers = authorizedHeaders(this.userService.apiToken);
     return jfetch<IRecentEventsConfig>(url, { headers }).catch(() => {
       console.warn('Error fetching recent events config');
@@ -492,9 +490,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
 
   fetchMediaShareState() {
     // eslint-disable-next-line
-    const url = `https://${
-      this.hostsService.streamlabs
-    }/api/v5/slobs/widget/config?widget=media-sharing`;
+    const url = `${this.urlService.streamlabsBase}/api/v5/slobs/widget/config?widget=media-sharing`;
     const headers = authorizedHeaders(this.userService.apiToken);
     return jfetch<{ settings: { advanced_settings: { enabled: boolean } } }>(url, {
       headers,
@@ -585,7 +581,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
   }
 
   async fetchReadReceipts(hashValues: string): Promise<{ data: Dictionary<boolean> }> {
-    const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/readreceipts`;
+    const url = `${this.urlService.streamlabsBase}/api/v5/slobs/readreceipts`;
     const headers = authorizedHeaders(
       this.userService.apiToken,
       new Headers({ 'Content-Type': 'application/json' }),
@@ -602,7 +598,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
       this.userService.apiToken,
       new Headers({ 'Content-Type': 'application/json' }),
     );
-    const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/widget/repeatalert`;
+    const url = `${this.urlService.streamlabsBase}/api/v5/slobs/widget/repeatalert`;
     const body = JSON.stringify({
       data: event,
       type: event.type,
@@ -614,7 +610,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
   async readAlert(event: IRecentEvent) {
     this.TOGGLE_RECENT_EVENT_READ(event.uuid);
     const newEvent = this.views.getEvent(event.uuid);
-    const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/widget/readalert`;
+    const url = `${this.urlService.streamlabsBase}/api/v5/slobs/widget/readalert`;
     const headers = authorizedHeaders(
       this.userService.apiToken,
       new Headers({ 'Content-Type': 'application/json' }),
@@ -628,7 +624,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
   }
 
   async postUpdateFilterPreferences() {
-    const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/widget/recentevents`;
+    const url = `${this.urlService.streamlabsBase}/api/v5/slobs/widget/recentevents`;
     const headers = authorizedHeaders(
       this.userService.apiToken,
       new Headers({ 'Content-Type': 'application/json' }),
@@ -639,21 +635,21 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
   }
 
   async skipAlert() {
-    const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/alerts/skip`;
+    const url = `${this.urlService.streamlabsBase}/api/v5/slobs/alerts/skip`;
     const headers = authorizedHeaders(this.userService.apiToken);
     const request = new Request(url, { headers, method: 'POST' });
     return await fetch(request).then(handleResponse);
   }
 
   async pauseAlertQueue() {
-    const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/alerts/pause_queue`;
+    const url = `${this.urlService.streamlabsBase}/api/v5/slobs/alerts/pause_queue`;
     const headers = authorizedHeaders(this.userService.apiToken);
     const request = new Request(url, { headers, method: 'POST' });
     return fetch(request).then(handleResponse);
   }
 
   async unpauseAlertQueue() {
-    const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/alerts/unpause_queue`;
+    const url = `${this.urlService.streamlabsBase}/api/v5/slobs/alerts/unpause_queue`;
     const headers = authorizedHeaders(this.userService.apiToken);
     const request = new Request(url, { headers, method: 'POST' });
     return fetch(request).then(handleResponse);
@@ -915,9 +911,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
       new Headers({ 'Content-Type': 'application/json' }),
     );
     // eslint-disable-next-line
-    const url = `https://${
-      this.hostsService.streamlabs
-    }/api/v5/slobs/widget/recentevents/eventspanel`;
+    const url = `${this.urlService.streamlabsBase}/api/v5/slobs/widget/recentevents/eventspanel`;
     const body = JSON.stringify({ muted: !this.state.muted });
     return await fetch(new Request(url, { headers, body, method: 'POST' })).then(handleResponse);
   }
@@ -965,7 +959,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
   }
 
   fetchSafeModeStatus() {
-    const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/safemode`;
+    const url = `${this.urlService.streamlabsBase}/api/v5/slobs/safemode`;
     const headers = authorizedHeaders(this.userService.apiToken);
     return jfetch<{
       safe_mode_settings: { active: boolean; data: ISafeModeServerSettings; ends_at: number };
@@ -1016,7 +1010,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
       this.userService.apiToken,
       new Headers({ 'Content-Type': 'application/json' }),
     );
-    const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/safemode`;
+    const url = `${this.urlService.streamlabsBase}/api/v5/slobs/safemode`;
     const sm = this.state.safeMode;
     const body = JSON.stringify({
       clear_chat: sm.clearChat,
@@ -1042,7 +1036,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
     if (!this.state.safeMode.enabled) return;
 
     const headers = authorizedHeaders(this.userService.apiToken);
-    const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/safemode`;
+    const url = `${this.urlService.streamlabsBase}/api/v5/slobs/safemode`;
     this.SET_SAFE_MODE_SETTINGS({ loading: true });
     const promise = jfetch(new Request(url, { headers, method: 'DELETE' }));
 

--- a/app/services/scene-collections/server-api.ts
+++ b/app/services/scene-collections/server-api.ts
@@ -1,6 +1,6 @@
 import { Service } from 'services/core/service';
 import { Inject } from 'services/core/injector';
-import { HostsService } from 'services/hosts';
+import { HostsService, UrlService } from 'services/hosts';
 import { authorizedHeaders, jfetch } from 'util/requests';
 import { UserService } from 'services/user';
 
@@ -24,6 +24,7 @@ export interface ISceneCollectionsResponse {
  */
 export class SceneCollectionsServerApiService extends Service {
   @Inject() hostsService: HostsService;
+  @Inject() urlService: UrlService;
   @Inject() userService: UserService;
 
   /**
@@ -97,6 +98,6 @@ export class SceneCollectionsServerApiService extends Service {
   }
 
   private get baseUrl() {
-    return `https://${this.hostsService.overlays}/api`;
+    return `${this.urlService.protocol}${this.hostsService.overlays}/api`;
   }
 }

--- a/app/services/user/index.ts
+++ b/app/services/user/index.ts
@@ -4,7 +4,7 @@ import { handleResponse, authorizedHeaders, jfetch } from 'util/requests';
 import { mutation } from 'services/core/stateful-service';
 import { Service, Inject, ViewHandler } from 'services/core';
 import electron from 'electron';
-import { HostsService } from 'services/hosts';
+import { UrlService } from 'services/hosts';
 import {
   getPlatformService,
   IUserAuth,
@@ -149,7 +149,7 @@ class UserViews extends ViewHandler<IUserServiceState> {
 }
 
 export class UserService extends PersistentStatefulService<IUserServiceState> {
-  @Inject() private hostsService: HostsService;
+  @Inject() private urlService: UrlService;
   @Inject() private customizationService: CustomizationService;
   @Inject() private sceneCollectionsService: SceneCollectionsService;
   @Inject() private windowsService: WindowsService;
@@ -334,9 +334,8 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
   async validateLogin(): Promise<boolean> {
     if (!this.state.auth) return;
 
-    const host = this.hostsService.streamlabs;
     const headers = authorizedHeaders(this.apiToken);
-    const url = `https://${host}/api/v5/slobs/validate`;
+    const url = `${this.urlService.streamlabsBase}/api/v5/slobs/validate`;
     const request = new Request(url, { headers });
 
     const valid = await fetch(request).then(res => {
@@ -455,9 +454,8 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
   fetchLinkedPlatforms() {
     if (!this.isLoggedIn) return;
 
-    const host = this.hostsService.streamlabs;
     const headers = authorizedHeaders(this.apiToken);
-    const url = `https://${host}/api/v5/restream/user/info`;
+    const url = `${this.urlService.streamlabsBase}/api/v5/restream/user/info`;
     const request = new Request(url, { headers });
 
     return jfetch<ILinkedPlatformsResponse>(request).catch(() => {
@@ -470,8 +468,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
   }
 
   async setPrimeStatus() {
-    const host = this.hostsService.streamlabs;
-    const url = `https://${host}/api/v5/slobs/prime`;
+    const url = `${this.urlService.streamlabsBase}/api/v5/slobs/prime`;
     const headers = authorizedHeaders(this.apiToken);
     const request = new Request(url, { headers });
     return jfetch<{
@@ -614,7 +611,6 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
 
   recentEventsUrl() {
     if (!this.isLoggedIn) return '';
-    const host = this.hostsService.streamlabs;
     const token = this.widgetToken;
     const nightMode = this.customizationService.isDarkTheme ? 'night' : 'day';
     const isMediaShare =
@@ -623,7 +619,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
         ? '&view=media-share'
         : '';
 
-    return `https://${host}/dashboard/recent-events?token=${token}&mode=${nightMode}&electron${isMediaShare}`;
+    return `${this.urlService.streamlabsBase}/dashboard/recent-events?token=${token}&mode=${nightMode}&electron${isMediaShare}`;
   }
 
   dashboardUrl(subPage: string, hidenav: boolean = false) {
@@ -633,16 +629,13 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
     const i18nService = I18nService.instance as I18nService; // TODO: replace with getResource('I18nService')
     const locale = i18nService.state.locale;
     // eslint-disable-next-line
-    return `https://${
-      this.hostsService.streamlabs
-    }/slobs/dashboard?oauth_token=${token}&mode=${nightMode}&r=${subPage}&l=${locale}&hidenav=${hideNav}`;
+    return `${this.urlService.streamlabsBase}/slobs/dashboard?oauth_token=${token}&mode=${nightMode}&r=${subPage}&l=${locale}&hidenav=${hideNav}`;
   }
 
   appStoreUrl(appId?: string) {
-    const host = this.hostsService.platform;
     const token = this.apiToken;
     const nightMode = this.customizationService.isDarkTheme ? 'night' : 'day';
-    let url = `https://${host}/slobs-store`;
+    let url = `${this.urlService.streamlabsBase}/slobs-store`;
 
     if (appId) {
       url = `${url}/app/${appId}`;
@@ -653,7 +646,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
 
   overlaysUrl(type?: 'overlay' | 'widget-theme', id?: string) {
     const uiTheme = this.customizationService.isDarkTheme ? 'night' : 'day';
-    let url = `https://${this.hostsService.streamlabs}/library?mode=${uiTheme}&slobs`;
+    let url = `${this.urlService.streamlabsBase}/library?mode=${uiTheme}&slobs`;
 
     if (this.isLoggedIn) {
       url += `&oauth_token=${this.apiToken}`;
@@ -668,7 +661,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
 
   alertboxLibraryUrl(id?: string) {
     const uiTheme = this.customizationService.isDarkTheme ? 'night' : 'day';
-    let url = `https://${this.hostsService.streamlabs}/alertbox-library?mode=${uiTheme}&slobs`;
+    let url = `${this.urlService.streamlabsBase}/alertbox-library?mode=${uiTheme}&slobs`;
 
     if (this.isLoggedIn) {
       url += `&oauth_token=${this.apiToken}`;
@@ -680,8 +673,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
   }
 
   getDonationSettings() {
-    const host = this.hostsService.streamlabs;
-    const url = `https://${host}/api/v5/slobs/donation/settings`;
+    const url = `${this.urlService.streamlabsBase}/api/v5/slobs/donation/settings`;
     const headers = authorizedHeaders(this.apiToken);
     const request = new Request(url, { headers });
 


### PR DESCRIPTION
Twitch auth flow wasnt respecting proper protocol and local environment auth was not functioning.
There are still other areas this could be improved, and no other platforms were fixed.

Note: Twitch client id still needs to be manually overwritten.