### PR TITLE
fix preset filter issue

### DIFF
--- a/app/components-react/pages/onboarding/HardwareSetup.tsx
+++ b/app/components-react/pages/onboarding/HardwareSetup.tsx
@@ -58,7 +58,7 @@ export function HardwareSetup() {
   function setPresetFilter(value: string) {
     if (!DefaultHardwareService.selectedVideoSource) return;
 
-    DefaultHardwareService.actions.setPresetFilter(value);
+    DefaultHardwareService.actions.setPresetFilter(value === 'none' ? '' : value);
 
     if (value === 'none') {
       SourceFiltersService.remove(DefaultHardwareService.selectedVideoSource.sourceId, '__PRESET');

--- a/app/services/scene-collections/nodes/sources.ts
+++ b/app/services/scene-collections/nodes/sources.ts
@@ -284,7 +284,7 @@ export class SourcesNode extends Node<ISchema, {}> {
 
       this.sourceFiltersService.loadFilterData(
         sourceInfo.id,
-        sourceInfo.filters.items.map(f => {
+        sourceCreateData[index].filters.map(f => {
           return {
             name: f.name,
             type: f.type,

--- a/app/services/scene-collections/nodes/sources.ts
+++ b/app/services/scene-collections/nodes/sources.ts
@@ -189,6 +189,10 @@ export class SourcesNode extends Node<ISchema, {}> {
       });
     });
 
+    const supportedPresets = this.sourceFiltersService.views.presetFilterOptions.map(
+      opt => opt.value,
+    );
+
     // This shit is complicated, IPC sucks
     const sourceCreateData = supportedSources.map(source => {
       // Universally disabled for security reasons
@@ -205,7 +209,22 @@ export class SourcesNode extends Node<ISchema, {}> {
         syncOffset: source.syncOffset,
         filters: source.filters.items
           .filter(filter => {
-            return filter.type !== 'face_mask_filter';
+            if (filter.type === 'face_mask_filter') {
+              return false;
+            }
+
+            // Work around an issue where we accidentaly had invalid filters
+            // in scene collections.
+            if (
+              filter.name === '__PRESET' &&
+              !supportedPresets.includes(
+                this.sourceFiltersService.views.parsePresetValue(filter.settings.image_path),
+              )
+            ) {
+              return false;
+            }
+
+            return true;
           })
           .map(filter => {
             if (filter.type === 'vst_filter') {

--- a/app/services/source-filters.ts
+++ b/app/services/source-filters.ts
@@ -112,7 +112,9 @@ class SourceFiltersViews extends ViewHandler<IFiltersServiceState> {
   }
 
   parsePresetValue(path: string) {
-    return path.match(/luts[\\\/][a-z_]+.png$/)[0];
+    const match = path.match(/luts[\\\/][a-z_]+.png$/);
+
+    return match ? match[0] : null;
   }
 
   filtersBySourceId(sourceId: string) {

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -285,14 +285,16 @@ export class SourcesService extends StatefulService<ISourcesState> {
 
     if (
       this.defaultHardwareService.state.defaultVideoDevice === obsInputSettings.video_device_id &&
-      this.defaultHardwareService.state.presetFilter !== ''
+      this.defaultHardwareService.state.presetFilter !== '' &&
+      this.defaultHardwareService.state.presetFilter !== 'none'
     ) {
       this.sourceFiltersService.addPresetFilter(id, this.defaultHardwareService.state.presetFilter);
     }
 
     if (
       this.defaultHardwareService.state.defaultVideoDevice === obsInputSettings.device &&
-      this.defaultHardwareService.state.presetFilter !== ''
+      this.defaultHardwareService.state.presetFilter !== '' &&
+      this.defaultHardwareService.state.presetFilter !== 'none'
     ) {
       this.sourceFiltersService.addPresetFilter(id, this.defaultHardwareService.state.presetFilter);
     }


### PR DESCRIPTION
The hardware onboarding step had an issue where when deselecting a filter, we would accidentally log the selected preset as `'none'` in the default hardware service.  When creating a new video capture source, we would create a filter with the LUT value `'none'` which resulted in an error.

This PR has two fixes:
- Fix the original issue of the bad value being stored in the default hardware service, leading to the invalid filters being created
- Prevent loading invalid filters when loading the scene collection, thereby helping people get out of this bad state they're in