### PR TITLE
ignore unknown obs recording signals

### DIFF
--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -957,6 +957,9 @@ export class StreamingService
         [EOBSOutputSignal.Stopping]: ERecordingState.Stopping,
       } as Dictionary<ERecordingState>)[info.signal];
 
+      // We received a signal we didn't recognize
+      if (!nextState) return;
+
       if (info.signal === EOBSOutputSignal.Start) {
         this.usageStatisticsService.recordFeatureUsage('Recording');
         this.usageStatisticsService.recordAnalyticsEvent('RecordingStatus', {


### PR DESCRIPTION
C++ team is adding a new signal to the recording encoder.  This change will just ignore the new signal until we can do a full integration on the frontend.