### PR TITLE
update node modules after ci update

### DIFF
--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -12,7 +12,7 @@
             "name": "node-libuiohook",
             "url": "https://slobs-node-libuiohook.s3-us-west-2.amazonaws.com/",
             "archive": "node-libuiohook-[VERSION]-[OS].tar.gz",
-            "version": "1.1.7",
+            "version": "1.1.8",
             "win64": true,
             "osx": true
         },
@@ -20,7 +20,7 @@
             "name": "node-fontinfo",
             "url": "https://slobs-node-fontinfo.s3-us-west-2.amazonaws.com/",
             "archive": "node-fontinfo-[VERSION]-[OS].tar.gz",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "win64": true,
             "osx": true
         },
@@ -28,7 +28,7 @@
             "name": "font-manager",
             "url": "https://slobs-font-manager.s3-us-west-2.amazonaws.com/",
             "archive": "font-manager-[VERSION]-[OS].tar.gz",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "win64": true,
             "osx": true
         },
@@ -36,7 +36,7 @@
             "name": "crash-handler",
             "url": "https://slobs-crash-handler.s3-us-west-2.amazonaws.com/",
             "archive": "crash-handler-[VERSION]-[OS].tar.gz",
-            "version": "1.2.3",
+            "version": "1.2.4",
             "win64": true,
             "osx": true
         },


### PR DESCRIPTION
CI configs for node modules was updater. New versions was release so we stay on current builds even without functional changes. 