### PR TITLE
Update osn to v0.21.3

### DIFF
--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
             "name": "obs-studio-node",
             "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
             "archive": "osn-[VERSION]-release-[OS].tar.gz",
-            "version": "0.21.2",
+            "version": "0.21.3",
             "win64": true,
             "osx": true
         },


### PR DESCRIPTION
Steven	Merge pull request #1124 from stream-labs/nullptrstring-crashfix
unknown	Fix crash, calldata_string returns null on empty strings