### PR TITLE
prioritize IPv4 addresses in remote control QR code

### DIFF
--- a/app/services/api/tcp-server/tcp-server.ts
+++ b/app/services/api/tcp-server/tcp-server.ts
@@ -228,7 +228,9 @@ export class TcpServerService
         });
       });
     });
-    return addresses;
+
+    // Sort IPv4 before IPv6
+    return addresses.sort((a, b) => parseInt(a.family[3], 10) - parseInt(b.family[3], 10));
   }
 
   generateToken(): string {


### PR DESCRIPTION
We expect this to result in faster connection behavior for most people, as there are some issues with connecting to local IPv6 from Android devices.