### PR TITLE
add offset to onMouseUp event

### DIFF
--- a/app/components-react/highlighter/ClipTrimmer.tsx
+++ b/app/components-react/highlighter/ClipTrimmer.tsx
@@ -110,7 +110,7 @@ export default function ClipTrimmer(props: { clip: IClip }) {
     } else {
       isScrubbing.current = false;
       const timelineWidth = timelineRef.current!.offsetWidth - 40;
-      const timelineOffset = timelineRef.current!.getBoundingClientRect().left;
+      const timelineOffset = timelineRef.current!.getBoundingClientRect().left + 20;
       playAt(((e.clientX - timelineOffset) / timelineWidth) * props.clip.duration!);
     }
   }


### PR DESCRIPTION
When clicking and dragging on the playhead, it tracks the mouse correctly, but when letting go, the playhead would be off a bit. 

This adds the same offset to onMouseUp that was added to onMouseMove so that the playhead starts where the cursor is when you let go of it. 