### PR TITLE
style adjustments for AddTabModal

### DIFF
--- a/app/components-react/pages/layout-editor/AddTabModal.tsx
+++ b/app/components-react/pages/layout-editor/AddTabModal.tsx
@@ -53,7 +53,7 @@ export default function AddTabModal() {
   }
 
   return (
-    <ModalLayout footer={<Footer />} wrapperStyle={{ width: '410px', height: '350px' }}>
+    <ModalLayout footer={<Footer />} wrapperStyle={{ width: '390px', height: '270px' }}>
       <Form>
         <CardInput
           value={icon}
@@ -69,7 +69,7 @@ export default function AddTabModal() {
           label={$t('Name')}
           value={name}
           onChange={setName}
-          style={{ marginTop: '8px' }}
+          style={{ marginTop: '10px', marginLeft: '-80px', marginRight: '3px' }}
           uncontrolled={false}
         />
       </Form>


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/1477223/170768389-18b403ee-cc2d-4f4d-b6e7-d91d9f7839ed.png)

After: 
![image](https://user-images.githubusercontent.com/1477223/170768422-31546026-9f0c-4997-b159-c8162b9a7460.png)

I felt as though there was too much empty space in this modal, which also resulted in things being a bit off-center. Reduced the overall size of the modal and made sure things were more properly aligned. 