### PR TITLE
match progress bar styles in onboarding

### DIFF
--- a/app/components-react/pages/onboarding/ThemeSelector.m.less
+++ b/app/components-react/pages/onboarding/ThemeSelector.m.less
@@ -103,10 +103,3 @@
 .preview.active {
   border: 1px solid var(--teal);
 }
-
-.progress-bar {
-  position: relative;
-  display: block !important;
-  width: 80% !important;
-  margin: 20% auto;
-}

--- a/app/components-react/pages/onboarding/ThemeSelector.tsx
+++ b/app/components-react/pages/onboarding/ThemeSelector.tsx
@@ -120,9 +120,9 @@ export function ThemeSelector() {
             )}
           </div>
         ) : (
-          <div className={styles.progressBar}>
-            <p>{$t('Installing theme...')}</p>
+          <div style={{ margin: 'auto', marginTop: 24, width: '80%' }}>
             <AutoProgressBar percent={progress} timeTarget={60 * 1000} />
+            <p>{$t('Installing theme...')}</p>
           </div>
         )}
       </div>


### PR DESCRIPTION
Before: 
![Streamlabs_OBS_t00esb3Mn7](https://user-images.githubusercontent.com/1477223/170775067-005816ed-1fe1-4ffc-a159-556cd61117ea.gif)

After: 
![electron_vX5YxTfZPH](https://user-images.githubusercontent.com/1477223/170775082-1a6be33e-229e-462d-ae39-7824d951d66b.gif)

Made the positioning of progress bars during onboarding consistent (between Theme Install and Optimizing)
