### PR TITLE
namespace service helper mutations to their parent service

### DIFF
--- a/app/services/api/external-api/audio/audio-source.ts
+++ b/app/services/api/external-api/audio/audio-source.ts
@@ -36,7 +36,7 @@ export interface IAudioSourceModel {
  * API for audio source management. Provides operations related to a single
  * audio source like set deflection and mute / unmute audio source.
  */
-@ServiceHelper()
+@ServiceHelper('AudioService')
 export class AudioSource implements ISerializable {
   @Inject() private audioService: InternalAudioService;
   @Inject() private sourcesService: InternalSourcesService;

--- a/app/services/api/external-api/scenes/scene-item-folder.ts
+++ b/app/services/api/external-api/scenes/scene-item-folder.ts
@@ -20,7 +20,7 @@ export interface ISceneItemFolderModel extends ISceneNodeModel {
  * other nodes based on this folder. For further scene item folder operations
  * see {@link SceneNode}, {@link Scene} and {@link SourcesService}.
  */
-@ServiceHelper()
+@ServiceHelper('ScenesService')
 export class SceneItemFolder extends SceneNode implements ISceneItemFolderModel {
   @Fallback() private sceneFolder: InternalSceneItemFolder;
   @InjectFromExternalApi() private sourcesService: SourcesService;

--- a/app/services/api/external-api/scenes/scene-item.ts
+++ b/app/services/api/external-api/scenes/scene-item.ts
@@ -146,7 +146,7 @@ export interface ISceneItemActions {
  * {@link SceneNode} and {@link Scene}. For source related operations see
  * {@link SourcesService}.
  */
-@ServiceHelper()
+@ServiceHelper('ScenesService')
 export class SceneItem extends SceneNode implements ISceneItemActions, ISceneItemModel {
   @Fallback() private sceneItem: InternalSceneItem;
   @InjectFromExternalApi() private sourcesService: SourcesService;

--- a/app/services/api/external-api/scenes/scene.ts
+++ b/app/services/api/external-api/scenes/scene.ts
@@ -26,7 +26,7 @@ export interface ISceneModel {
  * creating, reordering and removing sources from this scene. For more general
  * scene operations see {@link ScenesService}.
  */
-@ServiceHelper()
+@ServiceHelper('ScenesService')
 export class Scene implements ISceneModel, ISerializable {
   @InjectFromExternalApi() private scenesService: ScenesService;
   @InjectFromExternalApi() private sourcesService: SourcesService;

--- a/app/services/api/external-api/scenes/selection.ts
+++ b/app/services/api/external-api/scenes/selection.ts
@@ -28,7 +28,7 @@ export interface ISelectionModel {
  *
  * Use {@link Scene.getSelection} to fetch a new {@link Selection} object.
  */
-@ServiceHelper()
+@ServiceHelper('SelectionService')
 export class Selection implements ISceneItemActions, ISerializable {
   @InjectFromExternalApi() private sourcesService: SourcesService;
   @InjectFromExternalApi() private scenesService: ScenesService;

--- a/app/services/api/external-api/sources/source.ts
+++ b/app/services/api/external-api/sources/source.ts
@@ -35,7 +35,7 @@ export interface ISourceModel {
  * renaming the source or updating settings and properties form data. For more
  * scene related operations see {@link SceneNode} and {@link Scene}.
  */
-@ServiceHelper()
+@ServiceHelper('SourcesService')
 export class Source implements ISourceModel, ISerializable {
   @Inject('SourcesService') private internalSourcesService: InternalSourcesService;
   @Fallback() private source: InternalSource;

--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -331,7 +331,7 @@ export class AudioService extends StatefulService<IAudioSourcesState> {
   }
 }
 
-@ServiceHelper()
+@ServiceHelper('AudioService')
 export class AudioSource implements IAudioSourceApi {
   name: string;
   sourceId: string;

--- a/app/services/core/service-helper.ts
+++ b/app/services/core/service-helper.ts
@@ -14,8 +14,9 @@
 import { inheritMutations } from './stateful-service';
 import Utils from 'services/utils';
 
-export function ServiceHelper() {
+export function ServiceHelper(parentServiceName: string) {
   return function <T extends { new (...args: any[]): {} }>(constr: T) {
+    constr['_isHelperFor'] = parentServiceName;
     const klass = class extends constr {
       constructor(...args: any[]) {
         super(...args);

--- a/app/services/core/stateful-service.ts
+++ b/app/services/core/stateful-service.ts
@@ -20,8 +20,10 @@ function registerMutation(
   descriptor: PropertyDescriptor,
   options: IMutationOptions = {},
 ) {
-  const serviceName = target.constructor.name;
-  const mutationName = `${serviceName}.${methodName}`;
+  const serviceName = target.constructor._isHelperFor ?? target.constructor.name;
+  const mutationName = target.constructor._isHelperFor
+    ? `${serviceName}.${target.constructor.name}.${methodName}`
+    : `${serviceName}.${methodName}`;
   const opts: IMutationOptions = { unsafe: false, sync: true, ...options };
 
   target.originalMethods = target.originalMethods || {};
@@ -152,7 +154,7 @@ export function getModule(ModuleContainer: any): Module<any, any> {
   // filter inherited mutations
   for (const mutationName in prototypeMutations) {
     const serviceName = mutationName.split('.')[0];
-    if (serviceName !== ModuleContainer.name) continue;
+    if (serviceName !== (ModuleContainer._isHelperFor ?? ModuleContainer.name)) continue;
     mutations[mutationName] = prototypeMutations[mutationName];
   }
 

--- a/app/services/hotkeys.ts
+++ b/app/services/hotkeys.ts
@@ -688,7 +688,7 @@ export class HotkeysService extends StatefulService<IHotkeysServiceState> {
 /**
  * Represents a single bindable hotkey
  */
-@ServiceHelper()
+@ServiceHelper('HotkeysService')
 export class Hotkey implements IHotkey {
   actionName: string;
   sceneId?: string;

--- a/app/services/scenes/scene-folder.ts
+++ b/app/services/scenes/scene-folder.ts
@@ -11,7 +11,7 @@ import { ServiceHelper } from 'services/core';
 import compact from 'lodash/compact';
 import { assertIsDefined } from '../../util/properties-type-guards';
 
-@ServiceHelper()
+@ServiceHelper('ScenesService')
 export class SceneItemFolder extends SceneItemNode {
   name: string;
   sceneNodeType: TSceneNodeType = 'folder';

--- a/app/services/scenes/scene-item.ts
+++ b/app/services/scenes/scene-item.ts
@@ -33,7 +33,7 @@ import { assertIsDefined } from '../../util/properties-type-guards';
  * all of the information about that source, and
  * how it fits in to the given scene
  */
-@ServiceHelper()
+@ServiceHelper('ScenesService')
 export class SceneItem extends SceneItemNode {
   sourceId: string;
   name: string;

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -30,7 +30,7 @@ export interface ISceneHierarchy extends ISceneItemNode {
   children: ISceneHierarchy[];
 }
 
-@ServiceHelper()
+@ServiceHelper('ScenesService')
 export class Scene {
   id: string;
   name: string;

--- a/app/services/selection/global-selection.ts
+++ b/app/services/selection/global-selection.ts
@@ -14,7 +14,7 @@ import * as remote from '@electron/remote';
  * store in the SelectionService, and selecting items
  * actually selects them in OBS.
  */
-@ServiceHelper()
+@ServiceHelper('SelectionService')
 export class GlobalSelection extends Selection {
   @Inject() selectionService: SelectionService;
   @Inject() editorCommandsService: EditorCommandsService;

--- a/app/services/selection/selection.ts
+++ b/app/services/selection/selection.ts
@@ -20,7 +20,7 @@ import { ISelectionState, TNodesList } from './index';
 /**
  * Helper for working with multiple sceneItems
  */
-@ServiceHelper()
+@ServiceHelper('SelectionService')
 export class Selection {
   @Inject() scenesService: ScenesService;
 

--- a/app/services/sources/source.ts
+++ b/app/services/sources/source.ts
@@ -18,7 +18,7 @@ import omit from 'lodash/omit';
 import { assertIsDefined } from '../../util/properties-type-guards';
 import { SourceFiltersService } from '../source-filters';
 
-@ServiceHelper()
+@ServiceHelper('SourcesService')
 export class Source implements ISourceApi {
   sourceId: string;
   name: string;

--- a/app/services/widgets/widget-source.ts
+++ b/app/services/widgets/widget-source.ts
@@ -5,7 +5,7 @@ import { IWidgetSource, WidgetType, IWidgetData } from './index';
 import { WidgetSettingsService } from 'services/widgets';
 import Utils from '../utils';
 
-@ServiceHelper()
+@ServiceHelper('WidgetsService')
 export class WidgetSource implements IWidgetSource {
   @Inject() private sourcesService: SourcesService;
   @Inject() private widgetsService: WidgetsService;


### PR DESCRIPTION
All service helpers are now required to claim which service they are helpers for.

This is used to namespace their mutations.  For example, the mutation `Scene.SET_NODES_ORDER` would now be `ScenesService.Scene.SET_NODES_ORDER`.

The purpose for this change is to make it clear which mutations modify which service's state.  Since service helpers have mutations, but don't actually own their own state, this creates a runtime association between service helper mutations and the underlying state they are mutating.

This should fix a reactivity issue with the new `useModule` code.  Specifically, the `ReactRoot` component looks at mutation names to track which components have a dependency on which state.  This should resolve issues with reactivity related to mutations on service helpers.