### PR TITLE
add chat delay option

### DIFF
--- a/app/components/widgets/ChatBox.vue
+++ b/app/components/widgets/ChatBox.vue
@@ -20,6 +20,9 @@
     <v-form-group>
       <bool-input v-model="wData.settings.always_show_messages" :metadata="metadata.always_show_messages"/>
       <slider-input v-model="wData.settings.message_hide_delay" :metadata="metadata.message_hide_delay"/>
+    </v-form-group>
+    <v-form-group title="Chat Delay">
+      <slider-input v-model="wData.settings.message_show_delay" :metadata="metadata.message_show_delay"/>
       <bool-input title="Disable Message Animations" v-model="wData.settings.disable_message_animations" :metadata="metadata.disable_message_animations"/>
     </v-form-group>
   </validated-form>

--- a/app/services/widgets/settings/chat-box.ts
+++ b/app/services/widgets/settings/chat-box.ts
@@ -27,6 +27,7 @@ export interface IChatBoxSettings extends IWidgetSettings {
   always_show_messages: boolean;
   hide_common_chat_bots: boolean;
   message_hide_delay: number;
+  message_show_delay: number;
   text_size: 14;
   muted_chatters: string;
   hide_commands: boolean;
@@ -69,6 +70,10 @@ export class ChatBoxService extends WidgetSettingsService<IChatBoxData> {
         min: 0,
         max: 200,
       }),
+      message_show_delay: metadata.slider({
+        min: 0,
+        max: 6,
+      }),
       show_moderator_icons: metadata.bool({ title: $t('Show Moderator Badges') }),
       show_subscriber_icons: metadata.bool({ title: $t('Show Subscriber Badges') }),
       show_turbo_icons: metadata.bool({ title: $t('Show Turbo Badges') }),
@@ -104,6 +109,7 @@ export class ChatBoxService extends WidgetSettingsService<IChatBoxData> {
   protected patchAfterFetch(data: IChatBoxData): IChatBoxData {
     // backend accepts and returns message_hide_delay in different precision
     data.settings.message_hide_delay = Math.round(data.settings.message_hide_delay / 1000);
+    data.settings.message_show_delay = Math.round(data.settings.message_show_delay / 1000);
     return data;
   }
 }


### PR DESCRIPTION
Chatbox widget recently added a new "chat delay" setting that we hadn't implemented yet, this PR adds this new setting to our widget properties. 

Before: 
![image](https://user-images.githubusercontent.com/1477223/176202786-f577bf6b-1719-4c96-a855-0d43b90666c9.png)

After: 
![image](https://user-images.githubusercontent.com/1477223/176202925-76dab4f7-9636-4445-9d5b-5090b2d86dad.png)
