### PR TITLE
Update osn to v0.21.11

### DIFF
--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
             "name": "obs-studio-node",
             "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
             "archive": "osn-[VERSION]-release-[OS].tar.gz",
-            "version": "0.21.7",
+            "version": "0.21.11",
             "win64": true,
             "osx": true
         },


### PR DESCRIPTION
Eddy Gharbi	exclude mediasoup plugin from loading
Eddy Gharbi	Merge branch 'update-libobs-v27.5.43' of github.com:stream-labs/obs-studio-node into update-libobs-v27.5.40
Eddy Gharbi	Update libobs to v27.5.43