### PR TITLE
Update osn to v0.21.12

### DIFF
--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -5,6 +5,7 @@
             "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
             "archive": "osn-[VERSION]-release-[OS].tar.gz",
             "version": "0.21.12",
+            "mac_version": "0.21.7",
             "win64": true,
             "osx": true
         },

--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,8 +4,7 @@
             "name": "obs-studio-node",
             "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
             "archive": "osn-[VERSION]-release-[OS].tar.gz",
-            "version": "0.21.11",
-            "mac_version": "0.21.7",
+            "version": "0.21.12",
             "win64": true,
             "osx": true
         },


### PR DESCRIPTION
Eddy Gharbi	Merge branch 'staging' of github.com:stream-labs/obs-studio-node into update-libobs-v27.5.40
Eugen	Node obs log performance 2 (#1142)
Eugen	Optimized node_obs_log mutex lock (#1141)
Eugen	Retry obs_reset_video with default params if user ones fail (#1140)
Eugen	Corrupted config files (#1138)