### PR TITLE
A temporary work around for the test machine issue

### DIFF
--- a/test/regular/api/scenes.ts
+++ b/test/regular/api/scenes.ts
@@ -228,8 +228,7 @@ test('SceneItem.addFile()', async t => {
   scene.clear();
   scene.addFile(dataDir);
 
-  t.true(
-    sceneBuilder.isEqualTo(`
+  const success = sceneBuilder.isEqualTo(`
     sources-files
       html
         hello.html: browser_source
@@ -241,8 +240,13 @@ test('SceneItem.addFile()', async t => {
         chatbox.mp4: ffmpeg_source
       text
         hello.txt: text_gdiplus
-  `),
-  );
+  `);
+
+	// This is a workaround for the slow volume meter drawing on the test machines.
+	// We wait for some time to allow the UI to finalize initialization before app closing.
+	await new Promise(resolve => setTimeout(resolve, 10000));
+
+  t.true(success);
 });
 
 test('Try to make a not existing scene active', async t => {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
The change adds a delay to the `SceneItem.addFile()` test to allow the UI to finalize initialization before the application closes. This can be considered as a temporary workaround for the test machine issue which started to reproduce in 1.10.0.

### Motivation and Context
Currently, the `SceneItem.addFile()` sporadically fails on the test machines.  During the test, two video files are added to the scene. The UI adds volume meters for the both files but it happens **VERY SLOWLY** on those machines. The videos play, then the application closes and only at this moment volume meters UI are shown. When they are shown, `MixerVolmeter.mounted()` is called which creates a `Volmeter2d` object. Its constructor calls `this.subscribeVolmeter()` which gets the worker window id the following way: `this.workerId = electron.ipcRenderer.sendSync('getWorkerWindowId')`. Unfortunately, at this moment the worker window is already destroyed, so this fails:
```
ipcMain.on('getWorkerWindowId', event => {
  event.returnValue = workerWindow.webContents.id;
});
```
I could not find a simply way to fix it with additional conditions before accessing `workerWindow.webContents.id`.

### How Has This Been Tested?
The test fails sporadically without the fix. The test stops failing with the fix. It looks like the 10 second delay is enough.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] The code has been tested.

