### PR TITLE
fix bug with disconnecting from collab cam

### DIFF
--- a/app/services/guest-cam/index.ts
+++ b/app/services/guest-cam/index.ts
@@ -677,7 +677,7 @@ export class GuestCamService extends StatefulService<IGuestCamServiceState> {
   /**
    * Disconnects the currently connected guest
    */
-  disconnectGuest() {
+  async disconnectGuest() {
     // Add the stream id to the list of disconnected guests, so we don't
     // immediately connect to that same guest again until they are forced
     // to refresh the page.
@@ -685,7 +685,7 @@ export class GuestCamService extends StatefulService<IGuestCamServiceState> {
       this.disconnectedStreamIds.push(this.state.guestInfo.streamId);
     }
 
-    this.cleanUpSocketConnection();
+    await this.cleanUpSocketConnection();
     this.startListeningForGuests();
   }
 


### PR DESCRIPTION
This fixes a bug where clicking the Disconnect button will result in us disconnecting from the socket and not reconnecting so a new guest can connect.