### PR TITLE
Increase FB pages limit

### DIFF
--- a/app/services/hosts.ts
+++ b/app/services/hosts.ts
@@ -14,6 +14,7 @@ export class HostsService extends Service {
       return 'beta.streamlabs.com';
     }
 
+    // return 'stage6.streamlabs.com';
     return 'streamlabs.com';
   }
 

--- a/app/services/hosts.ts
+++ b/app/services/hosts.ts
@@ -14,7 +14,6 @@ export class HostsService extends Service {
       return 'beta.streamlabs.com';
     }
 
-    // return 'stage6.streamlabs.com';
     return 'streamlabs.com';
   }
 

--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -693,7 +693,7 @@ export class FacebookService
   private async fetchPages(): Promise<IFacebookPage[]> {
     return (
       await this.requestFacebook<{ data: IFacebookPage[] }>(
-        `${this.apiBase}/me/accounts?limit=50`,
+        `${this.apiBase}/me/accounts?limit=100`,
         this.oauthToken,
       )
     ).data;


### PR DESCRIPTION
Some users complained they could not see all their pages. Unfortunately, FB API doesn't provide a search feature for the endpoint we use. So I just increased the pages limit