### PR TITLE
Collab Cam Screenshare + Simulcasting + Plugin Compatibility

### DIFF
--- a/app/components-react/windows/GuestCamProperties.tsx
+++ b/app/components-react/windows/GuestCamProperties.tsx
@@ -59,6 +59,10 @@ class GuestCamModule {
     return this.GuestCamService.views.audioSourceId;
   }
 
+  get screenshareProducerSourceId() {
+    return this.GuestCamService.views.screenshareSourceId;
+  }
+
   get videoProducerSourceOptions() {
     const videoSourceType = byOS({ [OS.Windows]: 'dshow_input', [OS.Mac]: 'av_capture_input' });
 
@@ -80,12 +84,25 @@ class GuestCamModule {
     }));
   }
 
+  get screenshareProducerSourceOptions() {
+    return this.SourcesService.views.sources
+      .filter(s => s.video)
+      .map(s => ({
+        label: s.name,
+        value: s.sourceId,
+      }));
+  }
+
   get videoProducerSource() {
     return this.GuestCamService.views.videoSource;
   }
 
   get audioProducerSource() {
     return this.GuestCamService.views.audioSource;
+  }
+
+  get screenshareProducerSource() {
+    return this.GuestCamService.views.screenshareSource;
   }
 
   get availableSources() {
@@ -212,6 +229,8 @@ export default function GuestCamProperties() {
     audioProducerSource,
     audioProducerSourceId,
     audioProducerSourceOptions,
+    screenshareProducerSourceId,
+    screenshareProducerSourceOptions,
     produceOk,
     regeneratingLink,
     regenerateLink,
@@ -304,6 +323,16 @@ export default function GuestCamProperties() {
                 value={audioProducerSourceId}
                 onChange={s => GuestCamService.actions.setAudioSource(s)}
                 style={{ width: '45%', margin: 0 }}
+              />
+            </div>
+            <div>
+              <ListInput
+                label={$t('Share Video Source (Optional)')}
+                options={screenshareProducerSourceOptions}
+                value={screenshareProducerSourceId}
+                onChange={s => GuestCamService.actions.setScreenshareSource(s)}
+                style={{ width: 500, margin: 0 }}
+                allowClear
               />
             </div>
           </Form>

--- a/app/components-react/windows/GuestCamProperties.tsx
+++ b/app/components-react/windows/GuestCamProperties.tsx
@@ -325,7 +325,8 @@ export default function GuestCamProperties() {
                 style={{ width: '45%', margin: 0 }}
               />
             </div>
-            <div>
+            {/* TODO: Uncomment when new guest page is deployed */}
+            {/* <div>
               <ListInput
                 label={$t('Share Video Source (Optional)')}
                 options={screenshareProducerSourceOptions}
@@ -334,7 +335,7 @@ export default function GuestCamProperties() {
                 style={{ width: 500, margin: 0 }}
                 allowClear
               />
-            </div>
+            </div> */}
           </Form>
           {(!videoProducerSource || !audioProducerSource) && (
             <Alert

--- a/app/services/guest-cam/consumer.ts
+++ b/app/services/guest-cam/consumer.ts
@@ -15,6 +15,7 @@ export class Consumer extends MediasoupEntity {
     const guest = new Guest({ remoteProducer });
     this.guests.push(guest);
     guest.connect();
+    this.setConsumerPreferredLayers();
   }
 
   removeGuest(streamId: string) {
@@ -24,6 +25,15 @@ export class Consumer extends MediasoupEntity {
       this.guests[idx].destroy();
       this.guests.splice(idx, 1);
     }
+
+    this.setConsumerPreferredLayers();
+  }
+
+  setConsumerPreferredLayers() {
+    this.guests.forEach(guest => {
+      if (!guest.videoTrack) return;
+      guest.videoTrack.setConsumerPreferredLayers();
+    });
   }
 
   async createTransport(event: IConsumerCreatedEvent) {

--- a/app/services/guest-cam/mediasoup-entity.ts
+++ b/app/services/guest-cam/mediasoup-entity.ts
@@ -34,7 +34,9 @@ export abstract class MediasoupEntity {
       throw new Error('Attempted to make OBS request from destroyed entity');
     }
 
-    return this.guestCamService.makeObsRequest(this.sourceId, func, arg);
+    const ret = this.guestCamService.makeObsRequest(this.sourceId, func, arg);
+    this.log('OBS REQUEST', func, arg, ret);
+    return ret;
   }
 
   log(...args: unknown[]) {

--- a/app/services/guest-cam/producer.ts
+++ b/app/services/guest-cam/producer.ts
@@ -1,175 +1,239 @@
 import { MediasoupEntity } from './mediasoup-entity';
 import uuid from 'uuid/v4';
 import { Inject } from 'services/core';
-import { SourceFiltersService, UserService } from 'app-services';
-import { GuestCamService } from '.';
-import { EFilterDisplayType } from 'services/source-filters';
+import { SourceFiltersService, SourcesService, UserService } from 'app-services';
+import { GuestCamService, TConnectParams } from '.';
+import { EFilterDisplayType, TSourceFilterType } from 'services/source-filters';
+
+type TStreamType = 'camera' | 'screenshare';
+
+interface IStream {
+  id: string;
+  type: TStreamType;
+  videoSourceId: string;
+  audioSourceId: string;
+}
+
+interface RtpEncodingParameters {
+  maxBitrate: number;
+  scaleResolutionDownBy: number;
+}
 
 export class Producer extends MediasoupEntity {
   @Inject() userService: UserService;
   @Inject() guestCamService: GuestCamService;
   @Inject() sourceFiltersService: SourceFiltersService;
+  @Inject() sourcesService: SourcesService;
 
-  connected = false;
-
-  streamId: string;
   transportId: string;
 
-  async connect() {
+  streams: IStream[] = [];
+
+  addStream(videoSourceId: string, type: TStreamType, audioSourceId?: string) {
     return this.withMutex(async () => {
-      this.streamId = uuid();
+      const videoSource = this.sourcesService.views.getSource(videoSourceId);
+
+      if (!videoSource) {
+        // TODO error handling
+      }
+
+      const streamId = uuid();
+      this.streams.push({
+        id: streamId,
+        type,
+        videoSourceId,
+        audioSourceId,
+      });
+
+      // Start by setting up filters
+      this.setupFiltersOnSource(videoSourceId, 'video', streamId);
+      if (audioSourceId) this.setupFiltersOnSource(audioSourceId, 'audio', streamId);
+
       const result = await this.sendWebRTCRequest({
         type: 'createProducer',
         data: {
-          streamId: this.streamId,
-          type: 'stream',
+          streamId,
+          type: type === 'camera' ? 'stream' : 'screenshare',
           name: this.userService.views.platform.username,
-          tracks: 2,
+          tracks: audioSourceId ? 2 : 1,
         },
       });
-      this.log('Producer Created', result);
 
-      const webcamSourceId = this.guestCamService.views.videoSourceId;
-      const videoFilter = this.sourceFiltersService.views
-        .filtersBySourceId(webcamSourceId, true)
-        .find(f => f.type === 'mediasoupconnector_vfilter');
-      this.sourceFiltersService.setSettings(webcamSourceId, videoFilter.name, {
-        producerId: this.streamId,
+      if (!this.transportId) {
+        const turnConfig = await this.guestCamService.getTurnConfig();
+
+        result['iceServers'] = [turnConfig];
+
+        this.makeObsRequest('func_create_send_transport', result);
+      }
+
+      const encodings =
+        type === 'camera'
+          ? this.getCameraEncodingParameters(videoSource.height)
+          : this.getScreenshareEncodingParameters(videoSource.height);
+
+      const videoProduceResult = this.makeObsRequest('func_create_video_producer', {
+        id: videoSourceId,
+        encodings,
       });
+      this.log('Got Video Produce Result', videoProduceResult);
 
-      const micSourceId = this.guestCamService.views.audioSourceId;
-      const micFilter = this.sourceFiltersService.views
-        .filtersBySourceId(micSourceId, true)
-        .find(f => f.type === 'mediasoupconnector_afilter');
-      this.sourceFiltersService.setSettings(micSourceId, micFilter.name, {
-        producerId: this.streamId,
-      });
+      if (!this.transportId) {
+        if (!videoProduceResult.connect_params) {
+          throw new Error(
+            'Did not receive connect params, yet send transport is not yet connected!',
+          );
+        }
 
-      const turnConfig = await this.guestCamService.getTurnConfig();
+        await this.sendWebRTCRequest({
+          type: 'connectSendTransport',
+          data: videoProduceResult.connect_params,
+        });
 
-      result['iceServers'] = [turnConfig];
+        this.log('Connected Send Transport');
 
-      this.makeObsRequest('func_create_send_transport', result);
+        videoProduceResult.produce_params = this.makeObsRequest(
+          'func_connect_result',
+          'true',
+        ).produce_params;
 
-      const connectParams = this.makeObsRequest('func_create_audio_producer', { id: this.streamId })
-        .connect_params;
-
-      this.log('Got Connect Params', connectParams);
+        this.transportId = videoProduceResult.produce_params.transportId;
+      }
 
       await this.sendWebRTCRequest({
-        type: 'connectSendTransport',
-        data: connectParams,
-      });
-
-      this.log('Connected Send Transport');
-
-      // Always true - it's unclear what failure looks like from server
-      const audioProduceParams = this.makeObsRequest('func_connect_result', 'true').produce_params;
-
-      this.log('Got Audio Produce Params', audioProduceParams);
-
-      const audioProduceResult = await this.sendWebRTCRequest({
         type: 'addProducerTrack',
         data: {
-          streamId: this.streamId,
-          producerTransportId: audioProduceParams.transportId,
-          kind: audioProduceParams.kind,
-          rtpParameters: audioProduceParams.rtpParameters,
+          streamId,
+          producerTransportId: videoProduceResult.produce_params.transportId,
+          kind: videoProduceResult.produce_params.kind,
+          rtpParameters: videoProduceResult.produce_params.rtpParameters,
         },
       });
 
-      this.transportId = audioProduceParams.transportId;
-
-      // Always true - it's unclear what failure looks like from server
       this.makeObsRequest('func_produce_result', 'true');
 
-      this.log('Got Server Add Audio Track Result', audioProduceResult);
+      if (audioSourceId) {
+        const audioProduceParams = this.makeObsRequest('func_create_audio_producer', {
+          id: audioSourceId,
+        }).produce_params;
 
-      const videoProduceParams = this.makeObsRequest('func_create_video_producer', {
-        id: this.streamId,
-      }).produce_params;
+        this.log('Got Audio Produce Params', audioProduceParams);
 
-      this.log('Got Video Produce Params', videoProduceParams);
+        await this.sendWebRTCRequest({
+          type: 'addProducerTrack',
+          data: {
+            streamId,
+            producerTransportId: audioProduceParams.transportId,
+            kind: audioProduceParams.kind,
+            rtpParameters: audioProduceParams.rtpParameters,
+          },
+        });
 
-      const videoProduceResult = await this.sendWebRTCRequest({
-        type: 'addProducerTrack',
-        data: {
-          streamId: this.streamId,
-          producerTransportId: videoProduceParams.transportId,
-          kind: videoProduceParams.kind,
-          rtpParameters: videoProduceParams.rtpParameters,
-        },
-      });
+        // Always true - it's unclear what failure looks like from server
+        this.makeObsRequest('func_produce_result', 'true');
+      }
 
-      // Always true - it's unclear what failure looks like from server
-      this.makeObsRequest('func_produce_result', 'true');
-
-      this.log('Got Server Add Video Track Result', videoProduceResult);
-
-      this.connected = true;
       this.unlockMutex();
     });
   }
 
-  async addScreenShare(sourceId: string) {
-    const streamId = uuid();
-    const result = await this.sendWebRTCRequest({
-      type: 'createProducer',
-      data: {
-        streamId,
-        type: 'screenshare',
-        name: this.userService.views.platform.username,
-        tracks: 1,
-      },
-    });
-    this.log('Producer Created', result);
-
+  setupFiltersOnSource(sourceId: string, type: 'audio' | 'video', streamId: string) {
+    // Remove all mediasoup filters
     this.sourceFiltersService.views.filtersBySourceId(sourceId).forEach(filter => {
-      if (filter.type === 'mediasoupconnector_vsfilter') {
+      if (
+        [
+          'mediasoupconnector_afilter',
+          'mediasoupconnector_vfilter',
+          'mediasoupconnector_vsfilter',
+        ].includes(filter.type)
+      ) {
         this.sourceFiltersService.remove(sourceId, filter.name);
       }
     });
+
+    let filterType: TSourceFilterType = 'mediasoupconnector_afilter';
+    const source = this.sourcesService.views.getSource(sourceId);
+
+    if (!source) {
+      this.log('Tried to set up filter on source that does not exist!');
+      return;
+    }
+
+    if (type === 'video') {
+      if (['dshow_input', 'av_capture_input'].includes(source.type)) {
+        filterType = 'mediasoupconnector_vfilter';
+      } else {
+        filterType = 'mediasoupconnector_vsfilter';
+      }
+    }
+
     this.sourceFiltersService.add(
       sourceId,
-      'mediasoupconnector_vsfilter',
+      filterType,
       uuid(),
-      {
-        room: this.guestCamService.room,
-        producerId: streamId,
-      },
+      { room: this.guestCamService.room, producerId: sourceId },
       EFilterDisplayType.Hidden,
     );
+  }
 
-    const videoProduceParams = this.makeObsRequest('func_create_video_producer', {
-      id: streamId,
-    }).produce_params;
+  getCameraEncodingParameters(height: number): RtpEncodingParameters[] {
+    if (height > 720) {
+      return [
+        { maxBitrate: 256000, scaleResolutionDownBy: 4 },
+        { maxBitrate: 1200000, scaleResolutionDownBy: 2 },
+        { maxBitrate: 2400000, scaleResolutionDownBy: 1 },
+      ];
+    }
 
-    this.log('Got Video Produce Params', videoProduceParams);
+    if (height > 480) {
+      return [
+        { maxBitrate: 256000, scaleResolutionDownBy: 4 },
+        { maxBitrate: 512000, scaleResolutionDownBy: 2 },
+        { maxBitrate: 1500000, scaleResolutionDownBy: 1 },
+      ];
+    }
 
-    const videoProduceResult = await this.sendWebRTCRequest({
-      type: 'addProducerTrack',
-      data: {
-        streamId,
-        producerTransportId: videoProduceParams.transportId,
-        kind: videoProduceParams.kind,
-        rtpParameters: videoProduceParams.rtpParameters,
-      },
-    });
+    if (height > 360) {
+      return [
+        { maxBitrate: 300000, scaleResolutionDownBy: 2 },
+        { maxBitrate: 600000, scaleResolutionDownBy: 1 },
+        { maxBitrate: 600000, scaleResolutionDownBy: 1 },
+      ];
+    }
 
-    // Always true - it's unclear what failure looks like from server
-    this.makeObsRequest('func_produce_result', 'true');
+    return [
+      { maxBitrate: 200000, scaleResolutionDownBy: 2 },
+      { maxBitrate: 500000, scaleResolutionDownBy: 1 },
+      { maxBitrate: 500000, scaleResolutionDownBy: 1 },
+    ];
+  }
 
-    this.log('Got Server Add Video Track Result', videoProduceResult);
+  getScreenshareEncodingParameters(height: number): RtpEncodingParameters[] {
+    if (height > 720) {
+      return [{ maxBitrate: 2600000, scaleResolutionDownBy: 1 }];
+    }
+
+    if (height > 480) {
+      return [{ maxBitrate: 2000000, scaleResolutionDownBy: 1 }];
+    }
+
+    if (height > 360) {
+      return [{ maxBitrate: 1500000, scaleResolutionDownBy: 2 }];
+    }
+
+    return [{ maxBitrate: 1000000, scaleResolutionDownBy: 3 }];
   }
 
   destroy() {
-    this.makeObsRequest('func_stop_sender', '');
-    if (this.streamId && this.transportId) {
+    this.makeObsRequest('func_stop_sender');
+    this.streams.forEach(stream => {
+      this.makeObsRequest('func_stop_producer', stream.videoSourceId);
+      if (stream.audioSourceId) this.makeObsRequest('func_stop_producer', stream.audioSourceId);
       this.sendWebRTCRequest({
         type: 'closeProducerTrack',
-        data: { streamId: this.streamId, producerTransportId: this.transportId },
+        data: { streamId: stream.id, producerTransportId: this.transportId },
       });
-    }
+    });
     super.destroy();
   }
 }

--- a/app/services/scene-collections/nodes/guest-cam.ts
+++ b/app/services/scene-collections/nodes/guest-cam.ts
@@ -5,6 +5,7 @@ import { Node } from './node';
 interface ISchema {
   audioSourceId: string;
   videoSourceId: string;
+  screenshareSourceId?: string;
 }
 
 export class GuestCamNode extends Node<ISchema, {}> {

--- a/app/services/source-filters.ts
+++ b/app/services/source-filters.ts
@@ -48,7 +48,8 @@ export type TSourceFilterType =
   | 'expander_filter'
   | 'shader_filter'
   | 'mediasoupconnector_afilter'
-  | 'mediasoupconnector_vfilter';
+  | 'mediasoupconnector_vfilter'
+  | 'mediasoupconnector_vsfilter';
 
 interface ISourceFilterType {
   type: TSourceFilterType;
@@ -336,6 +337,15 @@ export class SourceFiltersService extends StatefulService<IFiltersServiceState> 
     setPropertiesFormData(obsFilter, properties);
     this.UPDATE_FILTER(sourceId, { name: filterName, settings: obsFilter.settings });
     this.filterUpdated.next({ sourceId, name: filterName });
+  }
+
+  setSettings(sourceId: string, filterName: string, settings: Dictionary<TObsValue>) {
+    if (!filterName) return;
+    const obsFilter = this.getObsFilter(sourceId, filterName);
+
+    obsFilter.update(settings);
+
+    this.UPDATE_FILTER(sourceId, { name: filterName, settings });
   }
 
   getFilters(sourceId: string): ISourceFilter[] {


### PR DESCRIPTION
Implements arbitrary video source sharing, multiple producer streams, and simulcasting based on source size.

Also implements compatibility with newest plugin.

Screenshare is hidden from the UI right now because it won't work with current production guest page.