### PR TITLE
video encoding grandfathering

### DIFF
--- a/app/components-react/pages/onboarding/Optimize.tsx
+++ b/app/components-react/pages/onboarding/Optimize.tsx
@@ -66,9 +66,6 @@ export function Optimize() {
           });
         }
       } else if (progress.event === 'done') {
-        // We also default on video encoding optimizations
-        VideoEncodingOptimizationService.actions.useOptimizedProfile(true);
-
         setProcessing(false);
         sub.unsubscribe();
         next();

--- a/app/components-react/windows/go-live/GoLiveSettings.tsx
+++ b/app/components-react/windows/go-live/GoLiveSettings.tsx
@@ -33,8 +33,15 @@ export default function GoLiveSettings() {
     isLoading,
     canAddDestinations,
     shouldShowPrimeLabel,
+    canUseOptimizedProfile,
   } = useGoLiveSettings().extend(module => {
-    const { RestreamService, SettingsService, UserService, MagicLinkService } = Services;
+    const {
+      RestreamService,
+      SettingsService,
+      UserService,
+      MagicLinkService,
+      VideoEncodingOptimizationService,
+    } = Services;
 
     return {
       get canAddDestinations() {
@@ -53,6 +60,10 @@ export default function GoLiveSettings() {
       },
 
       shouldShowPrimeLabel: !RestreamService.state.grandfathered,
+
+      canUseOptimizedProfile:
+        VideoEncodingOptimizationService.state.canSeeOptimizedProfile ||
+        VideoEncodingOptimizationService.state.useOptimizedProfile,
     };
   });
 
@@ -108,7 +119,7 @@ export default function GoLiveSettings() {
             {/*EXTRAS*/}
             <Section isSimpleMode={!isAdvancedMode} title={$t('Extras')}>
               <TwitterInput />
-              <OptimizedProfileSwitcher />
+              {!!canUseOptimizedProfile && <OptimizedProfileSwitcher />}
             </Section>
           </Scrollable>
         )}

--- a/app/services/video-encoding-optimizations/video-encoding-optimizations.ts
+++ b/app/services/video-encoding-optimizations/video-encoding-optimizations.ts
@@ -40,6 +40,13 @@ interface IVideoEncodingOptimizationServiceState {
   lastLoadedGame: string;
   lastLoadedProfiles: IEncoderProfile[];
   lastSelectedProfile: IEncoderProfile;
+
+  /**
+   * This flag exists to essentially grant grandfathered access to
+   * video encoding optimizations. This flag will be set if the user
+   * doesn't currently have the flag and has optimized profiles enabled.
+   */
+  canSeeOptimizedProfile: boolean;
 }
 
 export class VideoEncodingOptimizationService extends PersistentStatefulService<IVideoEncodingOptimizationServiceState> {
@@ -48,6 +55,7 @@ export class VideoEncodingOptimizationService extends PersistentStatefulService<
     lastLoadedGame: '',
     lastLoadedProfiles: [],
     lastSelectedProfile: null,
+    canSeeOptimizedProfile: null,
   };
 
   private previousSettings: {
@@ -64,6 +72,12 @@ export class VideoEncodingOptimizationService extends PersistentStatefulService<
 
   init() {
     super.init();
+
+    // Set grandfathered status
+    if (this.state.canSeeOptimizedProfile == null) {
+      this.SET_CAN_SEE_OPTIMIZED_PROFILE(this.state.useOptimizedProfile);
+    }
+
     this.streamingService.streamingStatusChange.subscribe(status => {
       if (status === EStreamingState.Offline && this.isUsingEncodingOptimizations) {
         this.isUsingEncodingOptimizations = false;
@@ -224,6 +238,11 @@ export class VideoEncodingOptimizationService extends PersistentStatefulService<
   @mutation()
   private SAVE_LAST_SELECTED_PROFILE(profile: IEncoderProfile) {
     this.state.lastSelectedProfile = profile;
+  }
+
+  @mutation()
+  SET_CAN_SEE_OPTIMIZED_PROFILE(val: boolean) {
+    this.state.canSeeOptimizedProfile = val;
   }
 }
 


### PR DESCRIPTION
Disables video encoding optimizations by default, but allows people with it already enabled to continue using it.