### PR TITLE
Chinese Traditional Translation Error

### DIFF
--- a/app/i18n/zh-TW/settings.json
+++ b/app/i18n/zh-TW/settings.json
@@ -131,7 +131,7 @@
   "Virtual Webcam requires administrator privileges to be installed on your system.": "虛擬網路攝影機需要管理員權限才能安裝在您系統上。",
   "Update Virtual Webcam": "更新虛擬網路攝影機",
   "Install Virtual Webcam": "安裝虛擬網路攝影機",
-  "Stop Virtual Webcam": "購買虛擬網路攝影機",
+  "Stop Virtual Webcam": "關閉虛擬網路攝影機",
   "Start Virtual Webcam": "啟動虛擬網路攝影機",
   "Virtual webcam is <status>Running</status>": "虛擬網路攝影機<status>執行中</status>",
   "Virtual webcam is <status>Offline</status>": "虛擬網路攝影機<status>離線</status>",


### PR DESCRIPTION
The "Stop Virtual Webcam" translation for zh-TW is incorrect right now, the current one means "Purchase Virtual Webcam".