### PR TITLE
Add 'screen_capture' to the macos supported source types

### DIFF
--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -109,6 +109,7 @@ export const macSources: TSourceType[] = [
   'coreaudio_output_capture',
   'av_capture_input',
   'display_capture',
+  'screen_capture',
   'audio_line',
   'ndi_source',
   'vlc_source',


### PR DESCRIPTION
### Description
This PR adds `screen_capture` to the supported source types on macOS.

### Motivation and Context
The source type is supported on macOS. Without the line the app shows a warning and resets scene collections every restart.

### How Has This Been Tested?
Check if the warning is shown and the scene collection is reset after restart with/without the fix.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] The code has been tested.
