### PR TITLE
Turn off Stream Scheduling for Facebook

### DIFF
--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -139,7 +139,6 @@ export class FacebookService
     'chat',
     'game',
     'user-info',
-    'stream-schedule',
     'account-merging',
     'streamlabels',
     'themes',


### PR DESCRIPTION
it appears as though FB has deprecated this feature