### PR TITLE
handle twitch scope missing error

### DIFF
--- a/app/components-react/pages/onboarding/Connect.tsx
+++ b/app/components-react/pages/onboarding/Connect.tsx
@@ -197,8 +197,24 @@ export class LoginModule {
     }
   }
 
-  finishSLAuth(primaryPlatform?: TPlatform) {
-    return this.UserService.finishSLAuth(primaryPlatform);
+  async finishSLAuth(primaryPlatform?: TPlatform) {
+    const result = await this.UserService.finishSLAuth(primaryPlatform);
+
+    if (result === EPlatformCallResult.TwitchScopeMissing) {
+      await remote.dialog.showMessageBox({
+        type: 'warning',
+        message: $t(
+          'Streamlabs requires additional permissions from your Twitch account. Please log in with Twitch to continue.',
+        ),
+        title: 'Twitch Error',
+        buttons: [$t('Refresh Login')],
+      });
+
+      // Initiate a Twitch merge to get permissions
+      await this.authPlatform('twitch', () => {}, true);
+    }
+
+    return result;
   }
 
   @mutation()

--- a/app/components-react/pages/onboarding/PrimaryPlatformSelect.tsx
+++ b/app/components-react/pages/onboarding/PrimaryPlatformSelect.tsx
@@ -52,6 +52,13 @@ export function PrimaryPlatformSelect() {
 
   // There's probably a better way to do this
   useEffect(() => {
+    // If user has exactly one streaming platform linked, we can proceed straight
+    // to a logged in state.
+    if (UserService.views.linkedPlatforms.length === 1) {
+      selectPrimary(UserService.views.linkedPlatforms[0]);
+      return;
+    }
+
     if (linkedPlatforms.length) {
       setSelectedPlatform(linkedPlatforms[0]);
     }
@@ -86,10 +93,10 @@ export function PrimaryPlatformSelect() {
     }
   }
 
-  async function selectPrimary() {
-    if (!selectedPlatform) return;
+  async function selectPrimary(primary?: TPlatform) {
+    if (!selectedPlatform && !primary) return;
 
-    await finishSLAuth(selectedPlatform as TPlatform);
+    await finishSLAuth(primary ?? (selectedPlatform as TPlatform));
     if (isLogin) OnboardingService.actions.finish();
   }
 
@@ -114,7 +121,7 @@ export function PrimaryPlatformSelect() {
             />
           </Form>
           <div style={{ width: 400, marginTop: 30, textAlign: 'center' }}>
-            <Button type="primary" disabled={loading} onClick={selectPrimary}>
+            <Button type="primary" disabled={loading} onClick={() => selectPrimary()}>
               {loading && <i className="fas fa-spinner fa-spin" />}
               {$t('Continue')}
             </Button>


### PR DESCRIPTION
These changes are meant to fix the following issue:
- Create a new SL ID from streamlabs.com without ever using it on desktop
- Link Twitch from the streamlabs.com dashboard
- Download desktop and log in with your SL ID
- (If you have multiple linked platforms, select Twitch as primary)
You will get stuck in an infinite login loop as long as you keep logging in with SL ID.  This is due to the fact that Twitch is missing the stream key oauth scope, but we never try to reauth Twitch to acquire the scope.  This resolves the issue by forcing a re-merge of Twitch when logging in with SL ID and Twitch primary.

There is unfortunately 1 remaining issue still, which is that we never actually check the presence of the scope if Twitch is not the primary platform.  So if Twitch is a secondary platform and was linked from the website, then it will have to be manually relinked in order to acquire the stream key scope.