### PR TITLE
fix(youtube): typo in scheduler auto-start option

### DIFF
--- a/app/services/platforms/youtube.ts
+++ b/app/services/platforms/youtube.ts
@@ -543,7 +543,7 @@ export class YoutubeService
     const contentDetails: Dictionary<any> = {
       enableAutoStart: isMidStreamMode
         ? broadcast.contentDetails.enableAutoStart
-        : params.enableAutoStop,
+        : params.enableAutoStart,
       enableAutoStop: params.enableAutoStop,
       enableDvr: params.enableDvr,
       enableEmbed: broadcast.contentDetails.enableEmbed,


### PR DESCRIPTION
Fix typo on `autoStop` option on YouTube stream scheduler's update method. 

This is the first part of the issue referenced here: https://app.asana.com/0/911512908891105/1202347443987242