### PR TITLE
fix(facebook): event doesn't appear on list after created until reload

### DIFF
--- a/app/components-react/pages/stream-scheduler/useStreamScheduler.tsx
+++ b/app/components-react/pages/stream-scheduler/useStreamScheduler.tsx
@@ -526,10 +526,14 @@ function convertYTBroadcastToEvent(ytBroadcast: IYoutubeLiveBroadcast): IStreamE
  * Converts FB liveVideo to IStreamEvent
  */
 function convertFBLiveVideoToEvent(fbLiveVideo: IFacebookLiveVideoExtended): IStreamEvent {
+  // Videos "just" created don't seem to have `broadcast_start_time`, fallback to planned.
+  const date = fbLiveVideo.broadcast_start_time || fbLiveVideo.planned_start_time;
+  assertIsDefined(date);
+
   return {
     platform: 'facebook',
     id: fbLiveVideo.id,
-    date: new Date(fbLiveVideo.broadcast_start_time).valueOf(),
+    date: new Date(date).valueOf(),
     title: fbLiveVideo.title,
     status: 'scheduled',
     facebook: {

--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -44,11 +44,14 @@ export interface IFacebookLiveVideo {
   id: string;
   stream_url: string;
   title: string;
+  /** @deprecated: doesn't exist on their API docs  */
   game: string;
   description: string;
   permalink_url: string;
   video: { id: string };
   broadcast_start_time: string;
+  planned_start_time?: string;
+  /** custom fields we've created */
   event_params: { start_time?: number; cover?: string; status?: TFacebookStatus };
 }
 


### PR DESCRIPTION
Newly-created `LiveVideo`'s do not seem to have `broadcast_start_time`,
which causes one of the many conversion logics around them to fail and
results in an invalid date, preventing the newly-created event from
showing on the list until the view is reloaded and data is fetched and
converted again.

NOTE: there's still a bug on the FB scheduler, clicking on any event does not
show the Edit modal, it fails to fetch the proper video/event
information (they're a mix at this point), revolving around
`fetchVideo` and `fetchStartStreamOptionsForVideo`.