### PR TITLE
fix(facebook): only send `event_params` if subkeys present

### DIFF
--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -292,8 +292,13 @@ export class FacebookService
     switchToLive = false,
   ): Promise<IFacebookLiveVideo> {
     const { title, description, game, privacy, event_params } = options;
-    const data: Dictionary<any> = { title, description, event_params };
+    const data: Dictionary<any> = { title, description };
+
     if (game) data.game_specs = { name: game };
+
+    if (Object.keys(event_params).length) {
+      data.event_params = event_params;
+    }
 
     if (event_params.start_time) {
       // convert plannedStartTime from milliseconds to seconds


### PR DESCRIPTION
Streaming from Go Live without an scheduled event causes `OAuth Exception: (#100) Broadcast does not associate with a Live Online Event" when calling update endpoint on Facebook API. Their docs mention these are "Parameters specific to Live Online Event broadcast.".

Assuming the fetch works correctly for such cases we can rely on whether any of it's info is set to check whether we should send it to the update endpoint.

ref: https://app.asana.com/0/734380881425048/1204374502675060/f