### PR TITLE
fix guest api for electron 22

### DIFF
--- a/app/components-react/shared/BrowserView.tsx
+++ b/app/components-react/shared/BrowserView.tsx
@@ -43,7 +43,12 @@ export default function BrowserView(p: BrowserViewProps) {
 
     if (p.enableGuestApi) {
       opts.webPreferences.contextIsolation = true;
-      opts.webPreferences.preload = path.resolve(remote.app.getAppPath(), 'bundles', 'guest-api');
+      opts.webPreferences.preload = path.resolve(
+        remote.app.getAppPath(),
+        'bundles',
+        'guest-api.js',
+      );
+      opts.webPreferences.sandbox = false;
     }
     return opts;
   }, [p.options]);

--- a/app/services/chat.ts
+++ b/app/services/chat.ts
@@ -149,7 +149,8 @@ export class ChatService extends Service {
         partition,
         nodeIntegration: false,
         contextIsolation: true,
-        preload: path.resolve(remote.app.getAppPath(), 'bundles', 'guest-api'),
+        preload: path.resolve(remote.app.getAppPath(), 'bundles', 'guest-api.js'),
+        sandbox: false,
       },
     });
 

--- a/app/services/platform-apps/container-manager.ts
+++ b/app/services/platform-apps/container-manager.ts
@@ -197,7 +197,8 @@ export class PlatformContainerManager {
         contextIsolation: true,
         nodeIntegration: false,
         partition: this.getAppPartition(app),
-        preload: path.resolve(remote.app.getAppPath(), 'bundles', 'guest-api'),
+        preload: path.resolve(remote.app.getAppPath(), 'bundles', 'guest-api.js'),
+        sandbox: false,
       },
     });
 


### PR DESCRIPTION
Electron 20 changed the default to `sandbox: true` which removes node APIs from preload scripts.

I would like to explore a future iteration that removes the need for the preload script to use node at all.