### PR TITLE
Fix facebook tests

### DIFF
--- a/app/components-react/windows/go-live/platforms/TrovoEditStreamInfo.tsx
+++ b/app/components-react/windows/go-live/platforms/TrovoEditStreamInfo.tsx
@@ -16,7 +16,7 @@ export function TrovoEditStreamInfo(p: IPlatformComponentParams<'trovo'>) {
   const bind = createBinding(trSettings, updatedSettings => updateSettings(updatedSettings));
 
   return (
-    <Form name="twitch-settings">
+    <Form name="trovo-settings">
       <PlatformSettingsLayout
         layoutMode={p.layoutMode}
         commonFields={

--- a/test/regular/streaming/facebook.ts
+++ b/test/regular/streaming/facebook.ts
@@ -14,7 +14,7 @@ import { click, focusChild, focusMain, select } from '../../helpers/modules/core
 
 useSpectron();
 
-test('Streaming to a Facebook Page', async t => {
+test.skip('Streaming to a Facebook Page', async t => {
   await logIn('facebook', { multistream: false });
   await goLive({
     title: 'SLOBS Test Stream',

--- a/test/regular/streaming/multistream.ts
+++ b/test/regular/streaming/multistream.ts
@@ -25,8 +25,8 @@ test('Multistream default mode', async t => {
   // enable all platforms
   await fillForm({
     twitch: true,
-    facebook: true,
     youtube: true,
+    trovo: true,
   });
   await waitForSettingsWindowLoaded();
 
@@ -54,8 +54,8 @@ test('Multistream advanced mode', async t => {
   // enable all platforms
   await fillForm({
     twitch: true,
-    facebook: true,
     youtube: true,
+    trovo: true,
   });
 
   await switchAdvancedMode();
@@ -77,12 +77,11 @@ test('Multistream advanced mode', async t => {
     description: 'youtube description',
   });
 
-  const facebookForm = useForm('facebook-settings');
+  const facebookForm = useForm('trovo-settings');
   await facebookForm.fillForm({
     customEnabled: true,
-    facebookGame: 'DOOM',
+    trovoGame: 'DOOM',
     title: 'facebook title',
-    description: 'facebook description',
   });
 
   await submit();

--- a/test/regular/streaming/multistream.ts
+++ b/test/regular/streaming/multistream.ts
@@ -80,7 +80,7 @@ test('Multistream advanced mode', async t => {
   const trovoForm = useForm('trovo-settings');
   await trovoForm.fillForm({
     customEnabled: true,
-    trovoGame: 'DOOM',
+    trovoGame: 'Doom',
     title: 'trovo title',
   });
 

--- a/test/regular/streaming/multistream.ts
+++ b/test/regular/streaming/multistream.ts
@@ -77,11 +77,11 @@ test('Multistream advanced mode', async t => {
     description: 'youtube description',
   });
 
-  const facebookForm = useForm('trovo-settings');
-  await facebookForm.fillForm({
+  const trovoForm = useForm('trovo-settings');
+  await trovoForm.fillForm({
     customEnabled: true,
     trovoGame: 'DOOM',
-    title: 'facebook title',
+    title: 'trovo title',
   });
 
   await submit();


### PR DESCRIPTION
- Switches multistream tests to use Trovo instead of FB
- Skip the one remaining facebook test that wasn't already disabled

We only have 1 multistream capable account in the user db after this.  I'm going to try to set up another with trovo so we don't get any conflicts.