### PR TITLE
Revert "Add 'screen_capture' to the macos supported source types"

### DIFF
--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -109,7 +109,6 @@ export const macSources: TSourceType[] = [
   'coreaudio_output_capture',
   'av_capture_input',
   'display_capture',
-  'screen_capture',
   'audio_line',
   'ndi_source',
   'vlc_source',


### PR DESCRIPTION
Reverts stream-labs/desktop#4458

Mistake has come from same source name was used for both windows and macos capture plugins. 
they are not compatible or interchangeable. 
https://github.com/stream-labs/obs-studio/commits/streamlabs/plugins/mac-capture/mac-screen-capture.m
