### PR TITLE
fix(collab-cam): guest screenshare doesn't show on stream or preview

### DIFF
--- a/app/services/guest-cam/guest-track.ts
+++ b/app/services/guest-cam/guest-track.ts
@@ -40,7 +40,7 @@ export class GuestTrack extends MediasoupEntity {
   /**
    * Requests this track from the server
    */
-  private requestTrack() {
+  requestTrack() {
     this.sendWebRTCRequest({
       type: 'getConsumerTrack',
       data: {

--- a/app/services/guest-cam/guest.ts
+++ b/app/services/guest-cam/guest.ts
@@ -63,7 +63,7 @@ export class Guest extends MediasoupEntity {
           sourceId: this.sourceId,
         });
 
-        await this.screenshareTrack.connect();
+        this.screenshareTrack.requestTrack();
       }
 
       this.consumerCreatedReady();
@@ -97,6 +97,20 @@ export class Guest extends MediasoupEntity {
 
       await this.videoTrack.connect();
     }
+
+    if (this.opts.remoteProducer.type === 'screenshare') {
+      // Replace screenshare track as we need to reassign source ID
+      this.screenshareTrack = new GuestTrack({
+        kind: 'video',
+        trackId: this.opts.remoteProducer.videoId,
+        socketId: this.opts.remoteProducer.socketId,
+        streamId: this.opts.remoteProducer.streamId,
+        transportId: this.transportId,
+        sourceId: this.sourceId,
+      });
+
+      await this.screenshareTrack.connect();
+    }
   }
 
   get streamId() {
@@ -122,6 +136,11 @@ export class Guest extends MediasoupEntity {
       if (this.videoTrack) {
         this.videoTrack.destroy();
         this.videoTrack = null;
+      }
+
+      if (this.screenshareTrack) {
+        this.screenshareTrack.destroy();
+        this.screenshareTrack = null;
       }
 
       if (sourceId) await this.createTracks();

--- a/app/services/guest-cam/index.ts
+++ b/app/services/guest-cam/index.ts
@@ -363,6 +363,14 @@ export class GuestCamService extends StatefulService<IGuestCamServiceState> {
       this.findDefaultSources();
     });
 
+    // Stop screen sharing if the user switches scenes as the source might not be available in the new scene
+    // TODO: consider checking if the source is in the new scene and don't stop sharing if so, might be expensive
+    this.scenesService.sceneSwitched.subscribe(() => {
+      if (this.views.screenshareSource) {
+        this.setScreenshareSource(null);
+      }
+    });
+
     this.streamingService.streamingStatusChange.subscribe(status => {
       if ([EStreamingState.Live, EStreamingState.Offline].includes(status)) {
         this.emitStreamingStatus();


### PR DESCRIPTION
Requesting a track is kind of eager and expects a source to be assigned, we needed to request without playing or connecting.

This should fix screenshare sources from guests not showing on stream or previews.