### PR TITLE
fix(twitch): shows VOD track when using different service in Advanced Mode

### DIFF
--- a/app/components-react/windows/advanced-audio/GlobalSettings.tsx
+++ b/app/components-react/windows/advanced-audio/GlobalSettings.tsx
@@ -28,7 +28,7 @@ export default function GlobalSettings() {
     streamTrack,
     vodTrack,
     vodTrackEnabled,
-    isTwitchAuthed,
+    isTwitchAuthedAndActive,
     recFormat,
   } = useVuex(() => ({
     advancedAudioSettings: SettingsService.views.advancedAudioSettings,
@@ -37,7 +37,7 @@ export default function GlobalSettings() {
     streamTrack: SettingsService.views.streamTrack,
     vodTrack: SettingsService.views.vodTrack,
     vodTrackEnabled: SettingsService.views.vodTrackEnabled,
-    isTwitchAuthed: UserService.views.isTwitchAuthed,
+    isTwitchAuthedAndActive: UserService.views.isTwitchAuthedAndActive,
     recFormat: SettingsService.views.recFormat,
   }));
 
@@ -96,7 +96,7 @@ export default function GlobalSettings() {
             onChange={value => handleOutputSettingsChange('TrackIndex', value)}
           />
         )}
-        {isAdvancedOutput && isTwitchAuthed && (
+        {isAdvancedOutput && isTwitchAuthedAndActive && (
           <SwitchInput
             label={$t('Enable Twitch VOD Track')}
             value={vodTrackEnabled}

--- a/app/components-react/windows/advanced-audio/GlobalSettings.tsx
+++ b/app/components-react/windows/advanced-audio/GlobalSettings.tsx
@@ -32,6 +32,7 @@ export default function GlobalSettings() {
     recFormat,
     isStreaming,
     isRecording,
+    isMultiStreaming,
   } = useVuex(() => ({
     advancedAudioSettings: SettingsService.views.advancedAudioSettings,
     isAdvancedOutput: SettingsService.views.isAdvancedOutput,
@@ -43,6 +44,7 @@ export default function GlobalSettings() {
     recFormat: SettingsService.views.recFormat,
     isStreaming: StreamingService.views.isStreaming,
     isRecording: StreamingService.views.isRecording,
+    isMultiStreaming: StreamingService.views.isMultiplatformMode,
   }));
 
   const monitoringDevice = advancedAudioSettings?.parameters.find(
@@ -66,6 +68,8 @@ export default function GlobalSettings() {
   function handleOutputSettingsChange(type: string, value: number | boolean) {
     SettingsService.actions.setSettingValue('Output', type, value);
   }
+
+  const shouldShowTwitchVODTrack = isAdvancedOutput && isTwitchAuthedAndActive && !isMultiStreaming;
 
   return (
     <>
@@ -101,22 +105,25 @@ export default function GlobalSettings() {
             disabled={isStreaming}
           />
         )}
-        {isAdvancedOutput && isTwitchAuthedAndActive && (
-          <SwitchInput
-            label={$t('Enable Twitch VOD Track')}
-            value={vodTrackEnabled}
-            onChange={value => handleOutputSettingsChange('VodTrackEnabled', value)}
-            disabled={isStreaming}
-          />
-        )}
-        {isAdvancedOutput && vodTrackEnabled && (
-          <ListInput
-            label={$t('Twitch VOD Track')}
-            value={vodTrack + 1}
-            options={trackOptions.filter(opt => opt.value !== streamTrack + 1)}
-            onChange={value => handleOutputSettingsChange('VodTrackIndex', value)}
-            disabled={isStreaming}
-          />
+        {shouldShowTwitchVODTrack && (
+          <>
+            <SwitchInput
+              label={$t('Enable Twitch VOD Track')}
+              value={vodTrackEnabled}
+              onChange={value => handleOutputSettingsChange('VodTrackEnabled', value)}
+              disabled={isStreaming}
+            />
+
+            {vodTrackEnabled && (
+              <ListInput
+                label={$t('Twitch VOD Track')}
+                value={vodTrack + 1}
+                options={trackOptions.filter(opt => opt.value !== streamTrack + 1)}
+                onChange={value => handleOutputSettingsChange('VodTrackIndex', value)}
+                disabled={isStreaming}
+              />
+            )}
+          </>
         )}
         {isAdvancedOutput && (
           <InputWrapper

--- a/app/components-react/windows/advanced-audio/GlobalSettings.tsx
+++ b/app/components-react/windows/advanced-audio/GlobalSettings.tsx
@@ -19,7 +19,7 @@ const trackOptions = [
 ];
 
 export default function GlobalSettings() {
-  const { SettingsService, UserService } = Services;
+  const { SettingsService, UserService, StreamingService } = Services;
 
   const {
     advancedAudioSettings,
@@ -30,6 +30,8 @@ export default function GlobalSettings() {
     vodTrackEnabled,
     isTwitchAuthedAndActive,
     recFormat,
+    isStreaming,
+    isRecording,
   } = useVuex(() => ({
     advancedAudioSettings: SettingsService.views.advancedAudioSettings,
     isAdvancedOutput: SettingsService.views.isAdvancedOutput,
@@ -39,6 +41,8 @@ export default function GlobalSettings() {
     vodTrackEnabled: SettingsService.views.vodTrackEnabled,
     isTwitchAuthedAndActive: UserService.views.isTwitchAuthedAndActive,
     recFormat: SettingsService.views.recFormat,
+    isStreaming: StreamingService.views.isStreaming,
+    isRecording: StreamingService.views.isRecording,
   }));
 
   const monitoringDevice = advancedAudioSettings?.parameters.find(
@@ -94,6 +98,7 @@ export default function GlobalSettings() {
             value={streamTrack + 1}
             options={trackOptions}
             onChange={value => handleOutputSettingsChange('TrackIndex', value)}
+            disabled={isStreaming}
           />
         )}
         {isAdvancedOutput && isTwitchAuthedAndActive && (
@@ -101,6 +106,7 @@ export default function GlobalSettings() {
             label={$t('Enable Twitch VOD Track')}
             value={vodTrackEnabled}
             onChange={value => handleOutputSettingsChange('VodTrackEnabled', value)}
+            disabled={isStreaming}
           />
         )}
         {isAdvancedOutput && vodTrackEnabled && (
@@ -109,6 +115,7 @@ export default function GlobalSettings() {
             value={vodTrack + 1}
             options={trackOptions.filter(opt => opt.value !== streamTrack + 1)}
             onChange={value => handleOutputSettingsChange('VodTrackIndex', value)}
+            disabled={isStreaming}
           />
         )}
         {isAdvancedOutput && (
@@ -127,7 +134,7 @@ export default function GlobalSettings() {
                   checkboxStyles={{ marginRight: '4px' }}
                   name={`flag${track}`}
                   onChange={(value: boolean) => handleTracksChange(i, value)}
-                  disabled={recFormat === 'flv'}
+                  disabled={isRecording || recFormat === 'flv'}
                 />
               ))}
             </div>

--- a/app/components-react/windows/settings/useObsSettings.tsx
+++ b/app/components-react/windows/settings/useObsSettings.tsx
@@ -21,7 +21,6 @@ class ObsSettingsModule {
     }
   }
 
-
   private get settingsService() {
     return Services.SettingsService;
   }

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -156,6 +156,10 @@ class SettingsViews extends ViewHandler<ISettingsServiceState> {
     return Utils.numberToBinnaryArray(this.values.Output.RecTracks, 6).reverse();
   }
 
+  get streamService() {
+    return this.values.Stream.service;
+  }
+
   get vodTrackEnabled() {
     return this.values.Output.VodTrackEnabled;
   }

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -156,7 +156,7 @@ class SettingsViews extends ViewHandler<ISettingsServiceState> {
     return Utils.numberToBinnaryArray(this.values.Output.RecTracks, 6).reverse();
   }
 
-  get streamService() {
+  get streamPlatform() {
     return this.values.Stream.service;
   }
 

--- a/app/services/user/index.ts
+++ b/app/services/user/index.ts
@@ -160,6 +160,14 @@ class UserViews extends ViewHandler<IUserServiceState> {
   // Injecting HostsService since it's not stateful
   @Inject() hostsService: HostsService;
 
+  get settingsServiceViews() {
+    return this.getServiceViews(SettingsService);
+  }
+
+  get streamSettingsServiceViews() {
+    return this.getServiceViews(StreamSettingsService);
+  }
+
   get customizationServiceViews() {
     return this.getServiceViews(CustomizationService);
   }
@@ -204,6 +212,25 @@ class UserViews extends ViewHandler<IUserServiceState> {
 
   get isTwitchAuthed() {
     return this.isLoggedIn && this.platform.type === 'twitch';
+  }
+
+  /*
+   * The method above doesn't take into account Advanced mode,
+   * resulting in platform-specific functionality (like VOD track on Twitch)
+   * to appear enabled when it shouldn't if the user has set a different Service
+   * in the advanced view.
+   *
+   * Does not modify the above method as we're not sure how many places this
+   * (perhaps more expensive) check is necessary, or whether it'd match the
+   * expected caller behavior.
+   *
+   * TODO: When going back to Recommended Settings, the Service setting here
+   * doesn't get reset.
+   */
+  get isTwitchAuthedAndActive() {
+    return this.streamSettingsServiceViews.state.protectedModeEnabled
+      ? this.isTwitchAuthed
+      : this.settingsServiceViews.streamService === 'Twitch';
   }
 
   get isFacebookAuthed() {

--- a/app/services/user/index.ts
+++ b/app/services/user/index.ts
@@ -230,7 +230,7 @@ class UserViews extends ViewHandler<IUserServiceState> {
   get isTwitchAuthedAndActive() {
     return this.streamSettingsServiceViews.state.protectedModeEnabled
       ? this.isTwitchAuthed
-      : this.settingsServiceViews.streamService === 'Twitch';
+      : this.settingsServiceViews.streamPlatform === 'Twitch';
   }
 
   get isFacebookAuthed() {


### PR DESCRIPTION
VOD track controls remain available with broken functionality if the
user is not in Protected Mode and has chosen a different service
from the Advanced Mode. This is present in the Global Audio Mixer
settings at the very least.

ref: https://app.asana.com/0/home/911512908736502/1204770688336817