### PR TITLE
Postpone duplicated scene removal till transition finished

### DIFF
--- a/app/services/transitions.ts
+++ b/app/services/transitions.ts
@@ -216,7 +216,7 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
     setTimeout(() => {
       oldDuplicate.release();
       this.studioModeLocked = false;
-    }, Math.min(transition.duration, TRANSITION_DURATION_MAX),);
+    }, Math.min(transition.duration, TRANSITION_DURATION_MAX));
   }
 
   /**

--- a/app/services/transitions.ts
+++ b/app/services/transitions.ts
@@ -213,13 +213,10 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
       this.sceneDuplicate,
     );
 
-    setTimeout(
-      () => {
-        oldDuplicate.release();
-        this.studioModeLocked = false;
-      },
-      Math.min(transition.duration, TRANSITION_DURATION_MAX),
-    );
+    setTimeout(() => {
+      oldDuplicate.release();
+      this.studioModeLocked = false;
+    }, Math.min(transition.duration, TRANSITION_DURATION_MAX),);
   }
 
   /**

--- a/app/services/transitions.ts
+++ b/app/services/transitions.ts
@@ -213,11 +213,13 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
       this.sceneDuplicate,
     );
 
-    oldDuplicate.release();
-
+    const releaseDelay = Math.min(transition.duration, TRANSITION_DURATION_MAX);
     setTimeout(
-      () => (this.studioModeLocked = false),
-      Math.min(transition.duration, TRANSITION_DURATION_MAX),
+      () => {
+        oldDuplicate.release();
+        this.studioModeLocked = false;
+      },
+      releaseDelay
     );
   }
 

--- a/app/services/transitions.ts
+++ b/app/services/transitions.ts
@@ -213,13 +213,12 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
       this.sceneDuplicate,
     );
 
-    const releaseDelay = Math.min(transition.duration, TRANSITION_DURATION_MAX);
     setTimeout(
       () => {
         oldDuplicate.release();
         this.studioModeLocked = false;
       },
-      releaseDelay
+      Math.min(transition.duration, TRANSITION_DURATION_MAX),
     );
   }
 


### PR DESCRIPTION
Calling oldDuplicate.release(); immediately after starting a transition will lead to removing scene in and transition fallback to default. 