### PR TITLE
fix(controls): timer input in Sponsor banner issues

### DIFF
--- a/app/components/shared/inputs/TimerInput.vue.ts
+++ b/app/components/shared/inputs/TimerInput.vue.ts
@@ -63,21 +63,21 @@ export default class TimerInput extends BaseInput<number, ITimerMetadata> {
     return second === currentSecond;
   }
 
-  setHour(val: number) {
+  setHour(val: string) {
     const currentMinsInSecs = Math.floor(this.value % 3600);
-    const hour = val * 3600;
+    const hour = parseInt(val, 10) * 3600;
     this.updateValue(currentMinsInSecs + hour);
   }
 
-  setMinute(val: number) {
+  setMinute(val: string) {
     const currentHrsInSecs = Math.floor(this.value / 3600) * 3600;
-    const minute = val * 60;
+    const minute = parseInt(val, 10) * 60;
     this.updateValue(currentHrsInSecs + minute);
   }
 
-  setSecond(val: number) {
+  setSecond(val: string) {
     const currentMinsInSecs = Math.floor((this.value % 3600) / 60) * 60;
-    this.updateValue(currentMinsInSecs + val);
+    this.updateValue(currentMinsInSecs + parseInt(val, 10));
   }
 
   updateValue(value: number) {

--- a/app/services/widgets/settings/sponsor-banner.ts
+++ b/app/services/widgets/settings/sponsor-banner.ts
@@ -76,9 +76,9 @@ export class SponsorBannerService extends WidgetSettingsService<ISponsorBannerDa
   }
 
   protected patchBeforeSend(settings: ISponsorBannerSettings): any {
-    settings.hide_duration = settings.hide_duration_in_seconds / 60;
+    settings.hide_duration = Math.round(settings.hide_duration_in_seconds / 60);
     settings.hide_duration_secs = settings.hide_duration_in_seconds % 60;
-    settings.show_duration = settings.show_duration_in_seconds / 60;
+    settings.show_duration = Math.round(settings.show_duration_in_seconds / 60);
     settings.show_duration_secs = settings.show_duration_in_seconds % 60;
 
     settings.image_1_href = settings.placement_1_images.map(image => image.href);


### PR DESCRIPTION
The legacy Vue Timer Input control used in the Sponsor Banner causes
issues as it seemed to fail to properly convert the dropdown values to a
number, resulting in the timer not being set correctly (at the very
least) when picking seconds, causing it to become stuck at 00:00 and
sending wrong (and very long) durations sent to the server, corrupting
the data.

I've found a couple of related issues not addressed in this PR:

* How to handle previous data set by users while the incorrect behavior
  existed, which prevents the time from being shown (it might be as
  simple as setting a new value within Desktop, or they might need to go
  to the Dashboard to fix).
* Control should auto-dismiss when picking seconds or clicking outside
  IMHO.

ref: https://app.asana.com/0/911512908891105/1204808187898806k