### PR TITLE
Fixed ERR_OSSL_EVP_UNSUPPORTED (#4631)

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -14,3 +14,8 @@ const antdlibSettings = JSON.parse(fs.readFileSync(antdLibSettingsPath, 'utf8'))
 delete antdlibSettings.module;
 antdlibSettings.main = 'dist/antd.min.js';
 fs.writeFileSync(antdLibSettingsPath, JSON.stringify(antdlibSettings, null, 2));
+
+// Fix hardcoded MD4
+if (process.platform === 'darwin') {
+  execSync("find node_modules/webpack/lib -type f -exec sed -i '' 's|md4|sha256|g' {} \\;", { stdio: [0, 1, 2] });
+}

--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -63,6 +63,7 @@ module.exports = {
     path: OUTPUT_DIR,
     filename: '[name].js',
     publicPath: '',
+    hashFunction: 'sha256',
   },
 
   target: 'electron-renderer',


### PR DESCRIPTION
Cherry Picking from staging to master

* Add --openssl-legacy-provider to the test environment

* Add --openssl-legacy-provider into npmrc

* Fix hardcoded MD4

* Remove extra line break