### PR TITLE
Handling errors in auto config

### DIFF
--- a/app/i18n/en-US/onboarding.json
+++ b/app/i18n/en-US/onboarding.json
@@ -136,5 +136,8 @@
   "Connect a Content Platform": "Connect a Content Platform",
   "Streamlabs Desktop requires that you have a connected platform account in order to use all of its features. By skipping this step, you will be logged out and some features may be unavailable.": "Streamlabs Desktop requires that you have a connected platform account in order to use all of its features. By skipping this step, you will be logged out and some features may be unavailable.",
   "Your Streamlabs account has multiple connected content platforms. Please select the primary platform you will be streaming to using Streamlabs Desktop.": "Your Streamlabs account has multiple connected content platforms. Please select the primary platform you will be streaming to using Streamlabs Desktop.",
-  "Streamlabs Desktop requires you to connect a content platform to your Streamlabs account": "Streamlabs Desktop requires you to connect a content platform to your Streamlabs account"
+  "Streamlabs Desktop requires you to connect a content platform to your Streamlabs account": "Streamlabs Desktop requires you to connect a content platform to your Streamlabs account",
+  "Error": "Error",
+  "Ok": "Ok",
+  "An error has occurred during optimization attempt. Only default settings are applied": "An error has occurred during optimization attempt. Only default settings are applied"
 }

--- a/app/services/auto-config/index.ts
+++ b/app/services/auto-config/index.ts
@@ -99,6 +99,8 @@ export class AutoConfigService extends Service {
 
     if (progress.event === 'error') {
       obs.NodeObs.StartSetDefaultSettings();
+      obs.NodeObs.TerminateAutoConfig();
+      this.configProgress.next(progress);
     }
 
     if (progress.event === 'done') {


### PR DESCRIPTION
Autoconfig was hanging infinitely on any error in sub-step.
I added proper error handling, which was not implemented initially.

Steps to reproduce:
- Start SL desktop
- Disconnect internet
- Open settings -> autoconfig (also known as 'optimizer')
- Press start
- Wait few seconds
- Connect internet again
- Wait for infinity and enjoy progress at 100%