### PR TITLE
fix user ip variable name

### DIFF
--- a/main.js
+++ b/main.js
@@ -325,7 +325,7 @@ async function startApp() {
         },
         globalExtra: {
           'sentry[release]': pjson.version,
-          'sentry[user][ip]': '{{auto}}',
+          'sentry[user][ip_address]': '{{auto}}',
         },
       });
     }


### PR DESCRIPTION
we should send it as "ip_address".
it will be changed to just "ip" when presented on sentry. 