### PR TITLE
com.apple.security.automation.apple-events

### DIFF
--- a/electron-builder/base.config.js
+++ b/electron-builder/base.config.js
@@ -82,6 +82,8 @@ const base = {
     entitlements: 'electron-builder/entitlements.plist',
     entitlementsInherit: 'electron-builder/entitlements.plist',
     extendInfo: {
+      NSAppleEventsUsageDescription: 'Allow Streamlabs Desktop to run Apple scripts.',
+      NSAppleScriptEnabled: 'YES',
       CFBundleURLTypes: [
         {
           CFBundleURLName: 'Streamlabs OBS Link',

--- a/electron-builder/entitlements.plist
+++ b/electron-builder/entitlements.plist
@@ -12,5 +12,7 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
Should fix this:

`Prompting policy for hardened runtime; service: kTCCServiceAppleEvents requires entitlement 
com.apple.security.automation.apple-events but it is missing for accessing=
{identifier=com.streamlabs.slobs, pid=876, auid=501, euid=501, 
binary_path=/Applications/Streamlabs Desktop.app/Contents/MacOS/Streamlabs Desktop}, 
requesting={identifier=com.apple.appleeventsd, pid=282, auid=55, euid=55, 
binary_path=/System/Library/CoreServices/appleeventsd},`