### PR TITLE
fix(editor): long scene collection names break UI

### DIFF
--- a/app/components-react/editor/elements/SceneSelector.m.less
+++ b/app/components-react/editor/elements/SceneSelector.m.less
@@ -48,6 +48,8 @@
   display: flex;
   align-items: center;
   min-width: 0;
+  // Fixes long scene collection names still pushing width even with overflow: hidden and text-overflow: ellipsis
+  max-width:  30vw;
 
   &:hover {
     cursor: pointer;


### PR DESCRIPTION
Long scene collection names break UI despite `text-overflow` and
`overflow` being used as it seems to still calculate width and push
everything to the right, resulting in the remaining columns to be pushed
offscreen.
Couldn't find a more elegant fix than setting `max-width` as some weird
layout / rendering / CSS quirk seems to be at play.

ref: https://app.asana.com/0/home/911512908736502/1205617568774831