### PR TITLE
fix(streamlabels): newlines not saved on streamlabel message format

### DIFF
--- a/app/services/sources/properties-managers/streamlabels-manager.ts
+++ b/app/services/sources/properties-managers/streamlabels-manager.ts
@@ -67,11 +67,11 @@ export class StreamlabelsManager extends DefaultManager {
     }
   }
 
-  normalizeText(text: string) {
+  normalizeText(text: string | undefined) {
     // When using `item_separator` for list items, it would appear that streamlabels will
     // send output like `foo\\nbar` instead of `foo\nbar`, normalize here.
     // We don't want to do it in settings since it would be sent to the backend
-    return text.replace('\\n', '\n');
+    return text?.replace('\\n', '\n');
   }
 
   applySettings(settings: Dictionary<any>) {

--- a/app/services/sources/properties-managers/streamlabels-manager.ts
+++ b/app/services/sources/properties-managers/streamlabels-manager.ts
@@ -24,10 +24,11 @@ export class StreamlabelsManager extends DefaultManager {
     this.subscription = this.streamlabelsService.output.subscribe(output => {
       if (output[this.settings.statname] !== this.oldOutput) {
         this.oldOutput = output[this.settings.statname];
+
         this.obsSource.update({
           ...this.obsSource.settings,
+          text: this.normalizeText(output[this.settings.statname]),
           read_from_file: false,
-          text: output[this.settings.statname],
         });
       }
     });
@@ -66,10 +67,17 @@ export class StreamlabelsManager extends DefaultManager {
     }
   }
 
+  normalizeText(text: string) {
+    // When using `item_separator` for list items, it would appear that streamlabels will
+    // send output like `foo\\nbar` instead of `foo\nbar`, normalize here.
+    // We don't want to do it in settings since it would be sent to the backend
+    return text.replace('\\n', '\n');
+  }
+
   applySettings(settings: Dictionary<any>) {
     if (settings.statname !== this.settings.statname) {
       this.obsSource.update({
-        text: this.streamlabelsService.output.getValue()[settings.statname],
+        text: this.normalizeText(this.streamlabelsService.output.getValue()[settings.statname]),
       });
     }
 

--- a/app/services/streamlabels/index.ts
+++ b/app/services/streamlabels/index.ts
@@ -243,6 +243,7 @@ export class StreamlabelsService extends StatefulService<IStreamlabelsServiceSta
 
   getSettingsForStat(statname: string) {
     const settings = { ...this.settings[statname] };
+    console.log('getting setting for ', statname, settings);
 
     if (settings.item_separator) {
       settings.item_separator = this.escapeNewline(settings.item_separator);
@@ -264,10 +265,6 @@ export class StreamlabelsService extends StatefulService<IStreamlabelsServiceSta
   }
 
   setSettingsForStat(statname: string, settings: IStreamlabelSettings): Promise<boolean> {
-    if (settings.item_separator) {
-      settings.item_separator = this.unescapeNewline(settings.item_separator);
-    }
-
     if (settings.format) {
       settings.format = this.unescapeNewline(settings.format);
     }

--- a/app/services/streamlabels/index.ts
+++ b/app/services/streamlabels/index.ts
@@ -244,10 +244,6 @@ export class StreamlabelsService extends StatefulService<IStreamlabelsServiceSta
   getSettingsForStat(statname: string) {
     const settings = { ...this.settings[statname] };
 
-    if (settings.item_separator) {
-      settings.item_separator = this.escapeNewline(settings.item_separator);
-    }
-
     if (settings.format) {
       settings.format = this.escapeNewline(settings.format);
     }

--- a/app/services/streamlabels/index.ts
+++ b/app/services/streamlabels/index.ts
@@ -245,15 +245,31 @@ export class StreamlabelsService extends StatefulService<IStreamlabelsServiceSta
     const settings = { ...this.settings[statname] };
 
     if (settings.item_separator) {
-      settings.item_separator = settings.item_separator.replace(/\n/gi, '\\n');
+      settings.item_separator = this.escapeNewline(settings.item_separator);
+    }
+
+    if (settings.format) {
+      settings.format = this.escapeNewline(settings.format);
     }
 
     return settings;
   }
 
+  escapeNewline(text: string) {
+    return text.replace(/\n/gi, '\\n');
+  }
+
+  unescapeNewline(text: string) {
+    return text.replace(/\\n/gi, '\n');
+  }
+
   setSettingsForStat(statname: string, settings: IStreamlabelSettings): Promise<boolean> {
     if (settings.item_separator) {
-      settings.item_separator = settings.item_separator.replace(/\\n/gi, '\n');
+      settings.item_separator = this.unescapeNewline(settings.item_separator);
+    }
+
+    if (settings.format) {
+      settings.format = this.unescapeNewline(settings.format);
     }
 
     this.settings[statname] = {

--- a/app/services/streamlabels/index.ts
+++ b/app/services/streamlabels/index.ts
@@ -243,7 +243,6 @@ export class StreamlabelsService extends StatefulService<IStreamlabelsServiceSta
 
   getSettingsForStat(statname: string) {
     const settings = { ...this.settings[statname] };
-    console.log('getting setting for ', statname, settings);
 
     if (settings.item_separator) {
       settings.item_separator = this.escapeNewline(settings.item_separator);


### PR DESCRIPTION
Fixes inputting a newline on the message format field of a Streamlabel
showing correctly on its preview, but not on the actual source or
persisted correctly on the backend.
Might also fix the item separator issue or is no longer present since
I couldn't reproduce this one.

ref: https://app.asana.com/0/734380881425048/1185957128889367/f