### PR TITLE
Remove unsafe macos entitlements

### DIFF
--- a/electron-builder/base.config.js
+++ b/electron-builder/base.config.js
@@ -63,6 +63,7 @@ const base = {
     },
   },
   mac: {
+    identity: (process.env.APPLE_SLD_IDENTITY) ? process.env.APPLE_SLD_IDENTITY : 'Streamlabs LLC (UT675MBB9Q)',
     extraFiles: [
       'shared-resources/**/*',
       '!shared-resources/README',

--- a/electron-builder/base.config.js
+++ b/electron-builder/base.config.js
@@ -112,6 +112,7 @@ const base = {
     sentryBackendClientURL: process.env.SLD_SENTRY_BACKEND_CLIENT_URL,
     sentryBackendClientPreviewURL: process.env.SLD_SENTRY_BACKEND_CLIENT_PREVIEW_URL,
   },
+  beforePack: './electron-builder/beforePack.js',
   afterPack: './electron-builder/afterPack.js',
   afterSign: './electron-builder/notarize.js',
 };

--- a/electron-builder/beforePack.js
+++ b/electron-builder/beforePack.js
@@ -2,9 +2,10 @@ const cp = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-function signAndCheck(filePath) {
+function signAndCheck(identity, filePath) {
   console.log(`Signing: ${filePath}`);
-  cp.execSync(`codesign -fs "Developer ID Application: Streamlabs LLC (UT675MBB9Q)" "${filePath}"`);
+
+  cp.execSync(`codesign -fs "Developer ID Application: ${identity}" "${filePath}"`);
 
   // All files need to be writable for update to succeed on mac
   console.log(`Checking Writable: ${filePath}`);
@@ -15,14 +16,14 @@ function signAndCheck(filePath) {
   }
 }
 
-function signBinaries(directory) {
+function signBinaries(identity, directory) {
   const files = fs.readdirSync(directory);
 
   for (const file of files) {
     const fullPath = path.join(directory, file);
 
     if (fs.statSync(fullPath).isDirectory()) {
-      signBinaries(fullPath);
+      signBinaries(identity, fullPath);
     } else {
       const absolutePath = path.resolve(fullPath);
       const ext = path.extname(absolutePath);
@@ -32,7 +33,7 @@ function signBinaries(directory) {
 
       // Sign dynamic libraries
       if (ext === '.node') {
-        signAndCheck(absolutePath);
+        signAndCheck(identity, absolutePath);
         continue;
       }
     }
@@ -43,10 +44,13 @@ exports.default = async function(context) {
   if (process.platform !== 'darwin') return;
   if (process.env.SLOBS_NO_SIGN) return;
 
+  console.log(JSON.stringify(context.packager.config));
+
   // Some *.node dynamic libraries do not go to the unpacked folder,
   // so we sign all *.node in the node_modules to be sure we can avoid
   // the com.apple.security.cs.disable-library-validation entitlement.
   signBinaries(
+    context.packager.config.mac.identity,
     `${context.packager.projectDir}/node_modules`,
   );
 };

--- a/electron-builder/beforePack.js
+++ b/electron-builder/beforePack.js
@@ -1,0 +1,52 @@
+const cp = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function signAndCheck(filePath) {
+  console.log(`Signing: ${filePath}`);
+  cp.execSync(`codesign -fs "Developer ID Application: Streamlabs LLC (UT675MBB9Q)" "${filePath}"`);
+
+  // All files need to be writable for update to succeed on mac
+  console.log(`Checking Writable: ${filePath}`);
+  try {
+    fs.accessSync(filePath, fs.constants.W_OK);
+  } catch {
+    throw new Error(`File ${filePath} is not writable!`);
+  }
+}
+
+function signBinaries(directory) {
+  const files = fs.readdirSync(directory);
+
+  for (const file of files) {
+    const fullPath = path.join(directory, file);
+
+    if (fs.statSync(fullPath).isDirectory()) {
+      signBinaries(fullPath);
+    } else {
+      const absolutePath = path.resolve(fullPath);
+      const ext = path.extname(absolutePath);
+
+      // Don't follow symbolic links
+      if (fs.lstatSync(absolutePath).isSymbolicLink()) continue;
+
+      // Sign dynamic libraries
+      if (ext === '.node') {
+        signAndCheck(absolutePath);
+        continue;
+      }
+    }
+  }
+}
+
+exports.default = async function(context) {
+  if (process.platform !== 'darwin') return;
+  if (process.env.SLOBS_NO_SIGN) return;
+
+  // Some *.node dynamic libraries do not go to the unpacked folder,
+  // so we sign all *.node in the node_modules to be sure we can avoid
+  // the com.apple.security.cs.disable-library-validation entitlement.
+  signBinaries(
+    `${context.packager.projectDir}/node_modules`,
+  );
+};

--- a/electron-builder/entitlements.plist
+++ b/electron-builder/entitlements.plist
@@ -8,9 +8,5 @@
     <true/>
     <key>com.apple.security.device.camera</key>
     <true/>
-    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true/>
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
Removed
`com.apple.security.cs.disable-library-validation`
`com.apple.security.cs.allow-dyld-environment-variables `