### PR TITLE
Update osn to v0.24.13

### DIFF
--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "0.24.11",
+      "version": "0.24.13",
       "win64": true,
       "osx": true
     },


### PR DESCRIPTION
Vladimir	Update codecs settings to support changes  (#1403)
Vladimir	Merge pull request #1404 from stream-labs/delay-encoder-destruction
Vladimir	Merge pull request #1402 from stream-labs/fix-encoder-crash-on-rtmp-connect
Aleksandr Voitenko	Delaying encoder destruction
Aleksandr Voitenko	Using obs_output_is_ready_to_update instead of obs_output_active in getAdvancedOutputStreamingSettings