### PR TITLE
Add fallback for unrecognized transitions

### DIFF
--- a/app/services/transitions.ts
+++ b/app/services/transitions.ts
@@ -412,6 +412,9 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
   }
 
   createTransition(type: ETransitionType, name: string, options: ITransitionCreateOptions = {}) {
+    if (!this.views.getTypes().find(t => t.value === type)) {
+      type = ETransitionType.Cut;
+    }
     const id = options.id || uuid();
     const transition = obs.TransitionFactory.create(type, id, options.settings || {});
     const manager = new DefaultManager(transition, options.propertiesManagerSettings || {});


### PR DESCRIPTION
Be useful in rare case when user had set some transition in preview and then switch back to live version what does not support it yet. 