### PR TITLE
fix(dual-output): missing Filters, Rename, Properties from ctx menu

### DIFF
--- a/app/components-react/editor/elements/SourceSelector.tsx
+++ b/app/components-react/editor/elements/SourceSelector.tsx
@@ -375,7 +375,6 @@ export class SourceSelectorModule {
        * clicking on the source selector selects both sources
        */
       if (
-        this.dualOutputService.views.dualOutputMode &&
         this.dualOutputService.views.hasNodeMap(this.scene.id) &&
         this.dualOutputService.views.activeDisplays.horizontal &&
         this.dualOutputService.views.activeDisplays.vertical

--- a/app/components-react/editor/elements/SourceSelector.tsx
+++ b/app/components-react/editor/elements/SourceSelector.tsx
@@ -375,6 +375,7 @@ export class SourceSelectorModule {
        * clicking on the source selector selects both sources
        */
       if (
+        this.dualOutputService.views.dualOutputMode &&
         this.dualOutputService.views.hasNodeMap(this.scene.id) &&
         this.dualOutputService.views.activeDisplays.horizontal &&
         this.dualOutputService.views.activeDisplays.vertical

--- a/app/util/menus/EditMenu.ts
+++ b/app/util/menus/EditMenu.ts
@@ -103,7 +103,7 @@ export class EditMenu extends Menu {
        * work, we can only assume the commands use `lastSelectedId` or similar access method
        * to determine which node to work with. Needs to be confirmed with testing.
        */
-      if (this.dualOutputService.views.dualOutputMode && this.options.display) {
+      if (this.dualOutputService.views.dualOutputMode) {
         const size = this.selectionService.views.globalSelection.getSize();
 
         if (size !== 2) {

--- a/app/util/menus/EditMenu.ts
+++ b/app/util/menus/EditMenu.ts
@@ -87,7 +87,7 @@ export class EditMenu extends Menu {
       });
     }
 
-    const isSelectionSameNodeAcrossDisplays = () => {
+    const isSelectionSameNodeAcrossDisplays = (selectionSize: number) => {
       /*
        * Check that selection is only two nodes (same node, one for each display), this only
        * seems to happen when clicking a source from the source selector which selects the
@@ -103,32 +103,26 @@ export class EditMenu extends Menu {
        * work, we can only assume the commands use `lastSelectedId` or similar access method
        * to determine which node to work with. Needs to be confirmed with testing.
        */
-      if (this.dualOutputService.views.dualOutputMode) {
-        const size = this.selectionService.views.globalSelection.getSize();
-
-        if (size !== 2) {
-          return false;
-        }
-
-        const selectedItems = this.selectionService.views.globalSelection
-          .getItems()
-          .map(item => this.scenesService.views.getSceneItem(item.id));
-
-        const [first, second] = selectedItems;
-
-        const bothNodesHaveSameSourceId = first.sourceId === second.sourceId;
-
-        const bothNodesHaveDifferentDisplay = first.display !== second.display;
-
-        return bothNodesHaveSameSourceId && bothNodesHaveDifferentDisplay;
+      if (selectionSize !== 2) {
+        return false;
       }
 
-      return false;
+      const selectedItems = this.selectionService.views.globalSelection
+        .getItems()
+        .map(item => this.scenesService.views.getSceneItem(item.id));
+
+      const [first, second] = selectedItems;
+
+      const bothNodesHaveSameSourceId = first.sourceId === second.sourceId;
+
+      const bothNodesHaveDifferentDisplay = first.display !== second.display;
+
+      return bothNodesHaveSameSourceId && bothNodesHaveDifferentDisplay;
     };
 
+    const selectionSize = this.selectionService.views.globalSelection.getSize();
     const isMultipleSelection =
-      this.selectionService.views.globalSelection.getSize() > 1 &&
-      !isSelectionSameNodeAcrossDisplays();
+      selectionSize > 1 && !isSelectionSameNodeAcrossDisplays(selectionSize);
 
     if (this.options.showSceneItemMenu) {
       const selectedItem = this.selectionService.views.globalSelection.getLastSelected();

--- a/app/util/menus/EditMenu.ts
+++ b/app/util/menus/EditMenu.ts
@@ -87,7 +87,48 @@ export class EditMenu extends Menu {
       });
     }
 
-    const isMultipleSelection = this.selectionService.views.globalSelection.getSize() > 1;
+    const isSelectionSameNodeAcrossDisplays = () => {
+      /*
+       * Check that selection is only two nodes (same node, one for each display), this only
+       * seems to happen when clicking a source from the source selector which selects the
+       * source across both displays.
+       *
+       * When selection size is not 2, we can assume we're either working with a single node or actual
+       * multiple nodes (i.e not the same node across two displays).
+       *
+       * TODO: do we need to be more specific to detect if we're working with the same node?
+       * We've found `source_id` to be stable, but that might change across different source types.
+       *
+       * TODO: It doesn't seem like we need to adjust selection to have Filters, Rename, and Properties
+       * work, we can only assume the commands use `lastSelectedId` or similar access method
+       * to determine which node to work with. Needs to be confirmed with testing.
+       */
+      if (this.dualOutputService.views.dualOutputMode && this.options.display) {
+        const size = this.selectionService.views.globalSelection.getSize();
+
+        if (size !== 2) {
+          return false;
+        }
+
+        const selectedItems = this.selectionService.views.globalSelection
+          .getItems()
+          .map(item => this.scenesService.views.getSceneItem(item.id));
+
+        const [first, second] = selectedItems;
+
+        const bothNodesHaveSameSourceId = first.sourceId === second.sourceId;
+
+        const bothNodesHaveDifferentDisplay = first.display !== second.display;
+
+        return bothNodesHaveSameSourceId && bothNodesHaveDifferentDisplay;
+      }
+
+      return false;
+    };
+
+    const isMultipleSelection =
+      this.selectionService.views.globalSelection.getSize() > 1 &&
+      !isSelectionSameNodeAcrossDisplays();
 
     if (this.options.showSceneItemMenu) {
       const selectedItem = this.selectionService.views.globalSelection.getLastSelected();


### PR DESCRIPTION
The "Filters", "Rename" and "Properties" options on the context menu when right-clicking on a source on the Editor is missing. 

This is due to selection having multiple elements and thus triggering the multiselection condition which hides these items. 
What really happens is that the selection is comprised of two nodes (one for each display), and while this behavior only seems to happen when selecting a source from the source pane, it has been reported to happen throughout the editor (I
can't verify).

Refactoring the Selection service is a more convoluted task so we've followed a similar approach to what the Edit Transform submenu item does but just to verify its condition (2 nodes but really 1 node across two displays), the 3 commands in question seem to grab a single selection item which should be one on the last display selected (gathered from the event) so while we need to test more we noticed these commands are working correctly (on said display).

ref: https://app.asana.com/0/734380881425048/1205635700788639/f