### PR TITLE
fix(dual-output): inconsistent source visibility status, details follow

### DIFF
--- a/app/components-react/editor/elements/DualOutputSourceSelector.tsx
+++ b/app/components-react/editor/elements/DualOutputSourceSelector.tsx
@@ -23,22 +23,13 @@ export function DualOutputSourceSelector(p: IDualOutputSourceSelector) {
       DualOutputService.views.verticalNodeIds && horizontalActive
         ? DualOutputService.views.activeSceneNodeMap[p.nodeId]
         : p.nodeId,
-    isHorizontalVisible:
-      !DualOutputService.views.isLoading &&
-      DualOutputService.views.getIsHorizontalVisible(p.nodeId, p?.sceneId),
-    isVerticalVisible:
-      !DualOutputService.views.isLoading &&
-      DualOutputService.views.getIsVerticalVisible(p.nodeId, p?.sceneId),
-    isLoading: DualOutputService.views.isLoading && !DualOutputService.views.hasVerticalNodes,
+    isHorizontalVisible: DualOutputService.views.getIsHorizontalVisible(p.nodeId, p?.sceneId),
+    isVerticalVisible: DualOutputService.views.getIsVerticalVisible(p.nodeId, p?.sceneId),
   }));
 
-  const showHorizontalToggle = useMemo(() => {
-    return !v.isLoading && horizontalActive;
-  }, [!v.isLoading, horizontalActive]);
+  const showHorizontalToggle = horizontalActive;
 
-  const showVerticalToggle = useMemo(() => {
-    return !v.isLoading && v?.verticalNodeId && verticalActive;
-  }, [!v.isLoading, v?.verticalNodeId, verticalActive]);
+  const showVerticalToggle = v.verticalNodeId && verticalActive;
 
   const horizontalToggleMessage = useMemo(() => {
     return v.isHorizontalVisible ? $t('Hide from Horizontal') : $t('Show in Horizontal');


### PR DESCRIPTION
Switching scenes makes dual-output horizontal/vertical visibility settings get into a weird state. Since restarting the app fixes it,
it shouldn't be a persistence problem.

I've found that having `isLoading` check prepended to the visibility booleans seems to be the root cause, as when switching scenes (see [dual-output.ts#327](https://github.com/stream-labs/desktop/blob/8995f39e250b68088b02df12cebb8fcb4143a517/app/services/dual-output/dual-output.ts#L327)), this triggers a load that apparently doesn't ever re-render the `DualOputputSourceSelector` component properly.

I haven't found any issues when removing these checks, but I've definitely just fixed the symptom here. If anything, we should probably move the check to the parent component, investigate why `isLoading` doesn't end up with a valid state, or both.

ref: https://app.asana.com/0/734380881425048/1206345543167836/f