### PR TITLE
fix(overlays): add locked status to overlays

### DIFF
--- a/app/services/scene-collections/nodes/overlays/slots.ts
+++ b/app/services/scene-collections/nodes/overlays/slots.ts
@@ -340,7 +340,7 @@ export class SlotsNode extends ArrayNode<TSlotSchema, IContext, TSceneNode> {
     }
 
     this.adjustTransform(sceneItem, obj);
-    this.setLockedStatus(sceneItem, obj);
+    this.setExtraSettings(sceneItem, obj);
 
     if (!existing) {
       await obj.content.load({
@@ -381,9 +381,14 @@ export class SlotsNode extends ArrayNode<TSlotSchema, IContext, TSceneNode> {
     });
   }
 
-  setLockedStatus(item: SceneItem, obj: IItemSchema) {
-    if (obj.locked === true) {
-      item.setLocked(true);
-    }
+  /*
+   * TODO: this is probably better than doing it individually on every source type
+   * branch, but might impact performance.
+   */
+  setExtraSettings(item: SceneItem, obj: IItemSchema) {
+    item.setSettings({
+      visible: obj.visible ?? true,
+      locked: obj.locked ?? false,
+    });
   }
 }

--- a/app/services/scene-collections/nodes/overlays/slots.ts
+++ b/app/services/scene-collections/nodes/overlays/slots.ts
@@ -59,6 +59,7 @@ interface IItemSchema {
 
   visible?: boolean;
   display?: TDisplayType;
+  locked: boolean;
 }
 
 export interface IFolderSchema {
@@ -122,6 +123,7 @@ export class SlotsNode extends ArrayNode<TSlotSchema, IContext, TSceneNode> {
           settings: filter.settings,
         };
       }),
+      locked: sceneNode.locked,
     };
 
     if (sceneNode.getObsInput().audioMixers) {
@@ -338,6 +340,8 @@ export class SlotsNode extends ArrayNode<TSlotSchema, IContext, TSceneNode> {
     }
 
     this.adjustTransform(sceneItem, obj);
+    this.setLockedStatus(sceneItem, obj);
+
     if (!existing) {
       await obj.content.load({
         sceneItem,
@@ -375,5 +379,11 @@ export class SlotsNode extends ArrayNode<TSlotSchema, IContext, TSceneNode> {
       crop: obj.crop,
       rotation: obj.rotation,
     });
+  }
+
+  setLockedStatus(item: SceneItem, obj: IItemSchema) {
+    if (obj.locked === true) {
+      item.setLocked(true);
+    }
   }
 }


### PR DESCRIPTION
Persist scene item's `locked` status on Scene Collection Export
and restore on load.

Partially addresses https://app.asana.com/0/734380881425048/1206825809745162/f