### PR TITLE
add max title length to tiktok

### DIFF
--- a/app/components-react/windows/go-live/CommonPlatformFields.tsx
+++ b/app/components-react/windows/go-live/CommonPlatformFields.tsx
@@ -51,6 +51,8 @@ export const CommonPlatformFields = InputComponent((rawProps: IProps) => {
   }
 
   function updateCommonField(fieldName: TCustomFieldName, value: string) {
+    console.log(value);
+    console.log(value.length)
     updatePlatform({ [fieldName]: value });
   }
 
@@ -100,7 +102,7 @@ export const CommonPlatformFields = InputComponent((rawProps: IProps) => {
               onChange={val => updateCommonField('title', val)}
               label={$t('Title')}
               required={true}
-              max={p.platform === 'twitch' ? 140 : 120}
+              max={p.platform === 'twitch' ? 140 : p.platform === 'tiktok' ? 32 : 120}
             />
 
             {/*DESCRIPTION*/}

--- a/app/components-react/windows/go-live/CommonPlatformFields.tsx
+++ b/app/components-react/windows/go-live/CommonPlatformFields.tsx
@@ -51,8 +51,6 @@ export const CommonPlatformFields = InputComponent((rawProps: IProps) => {
   }
 
   function updateCommonField(fieldName: TCustomFieldName, value: string) {
-    console.log(value);
-    console.log(value.length)
     updatePlatform({ [fieldName]: value });
   }
 


### PR DESCRIPTION
TikTok Live has a max title length of 32 characters. The API does not return an error, it simply cuts the title off at 32 characters, leading to unexpected behavior when a user uses a title longer than 32 characters. 

Currently this only works in Advanced Mode when using a custom title for TikTok, as I couldn't figure out how to make it work in simple mode / using same title across platforms. But also, 140 > 32 is such a stark drop in max characters that I felt like this might be too severe a change in behavior to do without consulting with maintainers. 