### PR TITLE
Return the disable-library-validation entitlement (master)

### DIFF
--- a/electron-builder/entitlements.plist
+++ b/electron-builder/entitlements.plist
@@ -10,5 +10,7 @@
     <true/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
The entitlement is required to load NDI dynamic libraries.