### PR TITLE
Return the disable-library-validation entitlement (staging)

### DIFF
--- a/electron-builder/entitlements.plist
+++ b/electron-builder/entitlements.plist
@@ -10,6 +10,8 @@
     <true/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
   </dict>


### PR DESCRIPTION
The entitlement is required to load NDI dynamic libraries.