### PR TITLE
fix(layout): attempt to fix layout editor issue, details follow

### DIFF
--- a/app/components-react/sidebar/EditorTabs.tsx
+++ b/app/components-react/sidebar/EditorTabs.tsx
@@ -43,9 +43,9 @@ export default function EditorTabs(p: IEditorTabs) {
 
   function navigateToStudioTab(tabId: string, trackingTarget: string, key: string) {
     if (currentMenuItem !== key) {
-      NavigationService.actions.navigate('Studio', { trackingTarget });
       LayoutService.actions.setCurrentTab(tabId);
       setCurrentMenuItem(key);
+      NavigationService.actions.navigate('Studio', { trackingTarget });
 
       // make sure custom editor setting is toggled on
       // if the active editor screen is not the default editor screen


### PR DESCRIPTION
We seem to be navigating before setting the LayoutEditor's current tab, which would probably mean the order is wrong or something in Editor at the very root is not reactive enough on `LayoutService.currentTab` to cause a re-render. As a result, clicking on a new layout editor tab from the sidebar shows the previous current tab before the call to `setCurrentTab` seems to take any effect.