### PR TITLE
fix(trovo): inject CSS style for chat width in Game Overlay

### DIFF
--- a/app/services/game-overlay/index.ts
+++ b/app/services/game-overlay/index.ts
@@ -43,6 +43,13 @@ const hideInteraction = `
   elements.forEach((el) => {
     if (el) { el.style.cssText = 'display: none !important'; }
   });
+  
+  // Trovo Chat
+  // Fix chat container that's cut off on Game Overlay's 300px wide window
+  const trovoChatContainer = document.querySelector('#__layout .popout-container .chat-wrap');
+  if (trovoChatContainer) {
+    container.style.minWidth = '300px';
+  }
 `;
 
 export enum EGameOverlayState {

--- a/app/services/game-overlay/index.ts
+++ b/app/services/game-overlay/index.ts
@@ -48,7 +48,7 @@ const hideInteraction = `
   // Fix chat container that's cut off on Game Overlay's 300px wide window
   const trovoChatContainer = document.querySelector('#__layout .popout-container .chat-wrap');
   if (trovoChatContainer) {
-    container.style.minWidth = '300px';
+    trovoChatContainer.style.minWidth = '300px';
   }
 `;
 
@@ -410,6 +410,7 @@ export class GameOverlayService extends PersistentStatefulService<GameOverlaySta
       this.overlay.setTransparency(overlayId, this.state.opacity * 2.55);
       this.overlay.setVisibility(overlayId, this.state.windowProperties[key].enabled);
 
+      win.webContents.openDevTools();
       win.webContents.executeJavaScript(hideInteraction);
       win.webContents.executeJavaScript(
         enableBTTVEmotesScript(this.customizationService.isDarkTheme),

--- a/app/services/game-overlay/index.ts
+++ b/app/services/game-overlay/index.ts
@@ -410,7 +410,6 @@ export class GameOverlayService extends PersistentStatefulService<GameOverlaySta
       this.overlay.setTransparency(overlayId, this.state.opacity * 2.55);
       this.overlay.setVisibility(overlayId, this.state.windowProperties[key].enabled);
 
-      win.webContents.openDevTools();
       win.webContents.executeJavaScript(hideInteraction);
       win.webContents.executeJavaScript(
         enableBTTVEmotesScript(this.customizationService.isDarkTheme),

--- a/app/services/game-overlay/index.ts
+++ b/app/services/game-overlay/index.ts
@@ -35,7 +35,7 @@ const hideInteraction = `
   /* Platform Chats */
   elements.push(document.querySelector('.chat-input'));
   elements.push(document.querySelector('.webComposerBlock__3lT5b'));
-
+  
   /* Recent Events */
   elements.push(document.querySelector('.recent-events__header'));
   elements.push(document.querySelector('.recent-events__tabs'));
@@ -48,7 +48,22 @@ const hideInteraction = `
   // Fix chat container that's cut off on Game Overlay's 300px wide window
   const trovoChatContainer = document.querySelector('#__layout .popout-container .chat-wrap');
   if (trovoChatContainer) {
-    trovoChatContainer.style.minWidth = '300px';
+    /* 
+     * The input box is rendered way after this code runs, insert a CSS rule to hide it instead of 
+     * manipulating style directly since we will never find the element here. 
+     * Since we're using CSSStyleSheet we add the rest of the rules here. 
+     * 
+     * 1. Fix chat wrapper width.
+     * 2. Hide chat input panel.
+     * 3. Hide Gift Rank header.
+     */
+    const el = document.createElement('style');
+    document.head.appendChild(el);
+    const sheet = el.sheet;
+    sheet.insertRule('#__layout .popout-container .chat-wrap { min-width: 300px }', sheet.cssRules.length);
+    sheet.insertRule('#__layout .popout-container .chat-wrap .chat-header { display: none }', sheet.cssRules.length);
+    sheet.insertRule('#__layout .popout-container .input-panels-container { display: none }', sheet.cssRules.length);
+    sheet.insertRule('#__layout .popout-container .gift-rank-header { display: none }', sheet.cssRules.length);
   }
 `;
 

--- a/app/services/game-overlay/index.ts
+++ b/app/services/game-overlay/index.ts
@@ -55,7 +55,7 @@ const hideInteraction = `
      * 
      * 1. Fix chat wrapper width.
      * 2. Hide chat input panel.
-     * 3. Hide Gift Rank header.
+     * 3. Hide all headers, including Gift Rank.
      */
     const el = document.createElement('style');
     document.head.appendChild(el);


### PR DESCRIPTION
Trovo chat gets cut-off because of a 350px wide requirement in their CSS, patches their CSS as part of the "hide interactions" section we seem to inject to the views.

ref: https://app.asana.com/0/734380881425048/1204613807236030/f