### PR TITLE
fix:(game-overlay): interaction controls weren't hiding for Twitch

### DIFF
--- a/app/services/game-overlay/index.ts
+++ b/app/services/game-overlay/index.ts
@@ -36,8 +36,7 @@ const hideInteraction = `
   // TODO: remove .chat-input if it was only for Twitch, as it wasn't working and fixed below
   elements.push(document.querySelector('.chat-input'));
   elements.push(document.querySelector('.webComposerBlock__3lT5b'));
-
-  /* Recent Events */
+  
   elements.forEach((el) => {
     if (el) { el.style.cssText = 'display: none !important'; }
   });

--- a/app/services/game-overlay/index.ts
+++ b/app/services/game-overlay/index.ts
@@ -33,16 +33,31 @@ const hideInteraction = `
   const elements = [];
 
   /* Platform Chats */
+  // TODO: remove .chat-input if it was only for Twitch, as it wasn't working and fixed below
   elements.push(document.querySelector('.chat-input'));
   elements.push(document.querySelector('.webComposerBlock__3lT5b'));
 
   /* Recent Events */
-  elements.push(document.querySelector('.recent-events__header'));
-  elements.push(document.querySelector('.recent-events__tabs'));
-  elements.push(document.querySelector('.popout--recent-events'));
   elements.forEach((el) => {
     if (el) { el.style.cssText = 'display: none !important'; }
   });
+  
+  const el = document.createElement('style');
+  document.head.appendChild(el);
+  const sheet = el.sheet;
+  
+  /* Recent Events */
+  sheet.insertRule('.recent-events__header, .recent-events__tabs, .popout--recent-events { display: none !important; }');
+  
+  // Twitch Chat
+  const twitchChatContainer = document.querySelector('#root .stream-chat');
+  
+  if (twitchChatContainer) {
+    // Header
+    sheet.insertRule('.stream-chat .stream-chat-header { display: none !important; }', sheet.cssRules.length);
+    // Chat Input
+    sheet.insertRule('.stream-chat .chat-input { display: none !important; }', sheet.cssRules.length);
+  }
   
   // Trovo Chat
   // Fix chat container that's cut off on Game Overlay's 300px wide window
@@ -57,9 +72,6 @@ const hideInteraction = `
      * 2. Hide chat input panel.
      * 3. Hide all headers, including Gift Rank.
      */
-    const el = document.createElement('style');
-    document.head.appendChild(el);
-    const sheet = el.sheet;
     sheet.insertRule('#__layout .popout-container .chat-wrap { min-width: 300px }', sheet.cssRules.length);
     sheet.insertRule('#__layout .popout-container .chat-wrap .chat-header { display: none }', sheet.cssRules.length);
     sheet.insertRule('#__layout .popout-container .input-panels-container { display: none }', sheet.cssRules.length);

--- a/app/services/game-overlay/index.ts
+++ b/app/services/game-overlay/index.ts
@@ -36,28 +36,28 @@ const hideInteraction = `
   // TODO: remove .chat-input if it was only for Twitch, as it wasn't working and fixed below
   elements.push(document.querySelector('.chat-input'));
   elements.push(document.querySelector('.webComposerBlock__3lT5b'));
-  
+
   elements.forEach((el) => {
     if (el) { el.style.cssText = 'display: none !important'; }
   });
-  
+
   const el = document.createElement('style');
   document.head.appendChild(el);
   const sheet = el.sheet;
-  
+
   /* Recent Events */
   sheet.insertRule('.recent-events__header, .recent-events__tabs, .popout--recent-events { display: none !important; }');
-  
+
   // Twitch Chat
   const twitchChatContainer = document.querySelector('#root .stream-chat');
-  
+
   if (twitchChatContainer) {
     // Header
     sheet.insertRule('.stream-chat .stream-chat-header { display: none !important; }', sheet.cssRules.length);
     // Chat Input
     sheet.insertRule('.stream-chat .chat-input { display: none !important; }', sheet.cssRules.length);
   }
-  
+
   // Trovo Chat
   // Fix chat container that's cut off on Game Overlay's 300px wide window
   const trovoChatContainer = document.querySelector('#__layout .popout-container .chat-wrap');

--- a/app/services/game-overlay/index.ts
+++ b/app/services/game-overlay/index.ts
@@ -35,7 +35,7 @@ const hideInteraction = `
   /* Platform Chats */
   elements.push(document.querySelector('.chat-input'));
   elements.push(document.querySelector('.webComposerBlock__3lT5b'));
-  
+
   /* Recent Events */
   elements.push(document.querySelector('.recent-events__header'));
   elements.push(document.querySelector('.recent-events__tabs'));


### PR DESCRIPTION
Twitch's chat input was still being shown, probably because their layout has changed or is rendered after the fact. We also hide the header. This is a similar fix to Trovo's, hence we depend on that PR. 