### PR TITLE
Fixes for studio mode and projector window

### DIFF
--- a/app/services/transitions.ts
+++ b/app/services/transitions.ts
@@ -207,7 +207,10 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
     this.SET_STUDIO_MODE(false);
     this.studioModeChanged.next(false);
 
-    obs.Global.removeSceneFromBackstage(this.studioModeTransition.getActiveSource());
+    const currentScene = this.scenesService.views.activeScene;
+    if (this.currentSceneId !== currentScene.id) {
+      obs.Global.removeSceneFromBackstage(this.studioModeTransition.getActiveSource());
+    }
 
     this.getCurrentTransition().set(this.scenesService.views.activeScene.getObsScene());
     this.releaseStudioModeObjects();

--- a/app/services/video.ts
+++ b/app/services/video.ts
@@ -310,8 +310,6 @@ export class VideoService extends Service {
   @Inject() dualOutputService: DualOutputService;
   @Inject() sourcesService: SourcesService;
 
-  displayNameToSceneSourceIdMap: Map<string, string> = new Map();
-
   init() {
     this.settingsService.loadSettingsIntoStore();
   }
@@ -401,12 +399,6 @@ export class VideoService extends Service {
         false,
         context,
       );
-
-      const source = this.sourcesService.views.getSource(sourceId);
-      if (source && source.type === 'scene') {
-        this.displayNameToSceneSourceIdMap.set(name, sourceId);
-        obs.Global.addSceneToBackstage(source.getObsInput());
-      }
     } else {
       obs.NodeObs.OBS_content_createDisplay(
         electronWindow.getNativeWindowHandle(),
@@ -436,14 +428,6 @@ export class VideoService extends Service {
 
   destroyOBSDisplay(name: string) {
     obs.NodeObs.OBS_content_destroyDisplay(name);
-
-    const sourceId = this.displayNameToSceneSourceIdMap.get(name);
-    if (sourceId) {
-      const source = this.sourcesService.views.getSource(sourceId);
-      if (source && source.type === 'scene') {
-        obs.Global.removeSceneFromBackstage(source.getObsInput());
-      }
-    }
   }
 
   getOBSDisplayPreviewOffset(name: string): IVec2 {

--- a/app/util/unload.ts
+++ b/app/util/unload.ts
@@ -2,11 +2,12 @@ import Utils from 'services/utils';
 
 /**
  * Helper for registering an action that needs to be performed on window refresh
- * Does nothing in production for now
  * @returns a function to cancel the unload operation
  */
 export function onUnload(fun: () => void) {
-  if (!Utils.isDevMode()) return () => {};
+  // This line was commented because without it in production build 'close' event is
+  // not fired for projector window immediately when it is closed, but fired on app close
+  //if (!Utils.isDevMode()) return () => {};
 
   window.addEventListener('beforeunload', fun);
 


### PR DESCRIPTION
Fixes for studio mode and projector window:
- Changes in `app/util/unload.ts` are required to handle correctly 'close' window event for scene projector
- Logic in `app/services/video.ts` is moved to `obs-studio-node` component, that's why code was deleted