### PR TITLE
fix(recent-events): tooltips have been missing since port

### DIFF
--- a/app/components-react/editor/elements/RecentEvents.tsx
+++ b/app/components-react/editor/elements/RecentEvents.tsx
@@ -8,6 +8,7 @@ import styles from './RecentEvents.m.less';
 import Scrollable from 'components-react/shared/Scrollable';
 import PlatformLogo from 'components-react/shared/PlatformLogo';
 import { Services } from 'components-react/service-provider';
+import { Tooltip } from 'antd';
 
 export default function RecentEvents(p: { isOverlay?: boolean }) {
   const { RecentEventsService } = Services;
@@ -44,57 +45,65 @@ function Toolbar() {
   );
 
   const pauseTooltip = queuePaused ? $t('Unpause Alert Queue') : $t('Pause Alert Queue');
+
   return (
     <div className={styles.topBar}>
       <h2 className="studio-controls__label">{$t('Mini Feed')}</h2>
       {spinWheelExists && (
-        <i
-          className="fas fa-chart-pie action-icon"
-          onClick={() => SpinWheelService.actions.spinWheel()}
-          v-tooltip={{ content: $t('Spin Wheel'), placement: 'bottom' }}
-        />
+        <Tooltip title={$t('Spin Wheel')} placement="bottom">
+          <i
+            className="fas fa-chart-pie action-icon"
+            onClick={() => SpinWheelService.actions.spinWheel()}
+          />
+        </Tooltip>
       )}
       {UserService.views.isTwitchAuthed && (
-        <i
-          className={cx('fa fa-shield-alt action-icon', {
-            [styles.teal]: safeModeEnabled,
-          })}
-          onClick={() => RecentEventsService.actions.showSafeModeWindow()}
-          v-tooltip={{ content: $t('Safe Mode'), placement: 'bottom' }}
-        />
+        <Tooltip title={$t('Safe Mode')} placement="bottom">
+          <i
+            className={cx('fa fa-shield-alt action-icon', {
+              [styles.teal]: safeModeEnabled,
+            })}
+            onClick={() => RecentEventsService.actions.showSafeModeWindow()}
+          />
+        </Tooltip>
       )}
-      <i
-        className="icon-filter action-icon"
-        onClick={() => RecentEventsService.actions.showFilterMenu()}
-        v-tooltip={{ content: $t('Popout Event Filtering Options'), placement: 'bottom' }}
-      />
+      <Tooltip title={$t('Popout Event Filtering Options')} placement="bottom">
+        <i
+          className="icon-filter action-icon"
+          onClick={() => RecentEventsService.actions.showFilterMenu()}
+        />
+      </Tooltip>
       {mediaShareEnabled && (
-        <i
-          className="icon-music action-icon"
-          onClick={() => RecentEventsService.actions.openRecentEventsWindow(true)}
-          v-tooltip={{ content: $t('Popout Media Share Controls'), placement: 'bottom' }}
-        />
+        <Tooltip title={$t('Popout Media Share Controls')} placement="bottom">
+          <i
+            className="icon-music action-icon"
+            onClick={() => RecentEventsService.actions.openRecentEventsWindow(true)}
+          />
+        </Tooltip>
       )}
-      <i
-        className={`${queuePaused ? 'icon-media-share-2' : 'icon-pause'} action-icon`}
-        onClick={() => RecentEventsService.actions.toggleQueue()}
-        v-tooltip={{ content: pauseTooltip, placement: 'left' }}
-      />
-      <i
-        className="icon-skip action-icon"
-        onClick={() => RecentEventsService.actions.skipAlert()}
-        v-tooltip={{ content: $t('Skip Alert'), placement: 'left' }}
-      />
-      <i
-        className={cx('action-icon', {
-          [styles.red]: muted,
-          fa: !muted,
-          'fa-volume-up': !muted,
-          'icon-mute': muted,
-        })}
-        onClick={() => RecentEventsService.actions.toggleMuteEvents()}
-        v-tooltip={{ content: $t('Mute Event Sounds'), placement: 'left' }}
-      />
+      <Tooltip title={pauseTooltip} placement="left">
+        <i
+          className={`${queuePaused ? 'icon-media-share-2' : 'icon-pause'} action-icon`}
+          onClick={() => RecentEventsService.actions.toggleQueue()}
+        />
+      </Tooltip>
+      <Tooltip title={$t('Skip Alert')} placement="left">
+        <i
+          className="icon-skip action-icon"
+          onClick={() => RecentEventsService.actions.skipAlert()}
+        />
+      </Tooltip>
+      <Tooltip title={$t('Mute Event Sounds')} placement="left">
+        <i
+          className={cx('action-icon', {
+            [styles.red]: muted,
+            fa: !muted,
+            'fa-volume-up': !muted,
+            'icon-mute': muted,
+          })}
+          onClick={() => RecentEventsService.actions.toggleMuteEvents()}
+        />
+      </Tooltip>
     </div>
   );
 }


### PR DESCRIPTION
Recent Events aka Mini Feed tooltips for the toolbar controls have possibly been missing since the React port. They were using `v-tooltip` and not being displayed.