### PR TITLE
Improved settings form behavior in errored state

### DIFF
--- a/app/components/obs/inputs/GenericForm.tsx
+++ b/app/components/obs/inputs/GenericForm.tsx
@@ -31,9 +31,34 @@ export default class GenericForm extends TsxComponent<GenericFormProps> {
     this.$emit('validate', errors);
   }
 
+  async onBlurHandler(event: FocusEvent) {
+    const errors = await this.$refs.form.validateAndGetErrors();
+    for (const e of errors) {
+      const inputs = this.$refs.form.getInputs();
+      const inputWithError = inputs.find((input) => {
+        return input.getOptions().uuid === e.field;
+      });
+
+      if (inputWithError) {
+        const name = inputWithError.getOptions()?.name;
+        const errorPropIndex = this.props.value.findIndex(p => p.name === name);
+
+        if (errorPropIndex !== -1) {
+          const errorProp = this.props.value[errorPropIndex];
+          // The trick with adding space symbol at the line below is used to force
+          // value refresh in UI, because UI's HTML element holds value with error and
+          // errorProp.value has the last valid value. Space addintion does not make value illegal,
+          // because it is pruned immediately automatically during error validation phase.
+          errorProp.value += ' ';
+          this.onInputHandler(errorProp, errorPropIndex);
+        }
+      }
+    }
+  }
+
   render() {
     return (
-      <ValidatedForm ref="form">
+      <ValidatedForm ref="form" onBlur={(event: FocusEvent) => this.onBlurHandler(event)}>
         {this.props.value.map((parameter, inputIndex) => {
           const Component = propertyComponentForType(parameter.type);
           return (

--- a/app/components/shared/inputs/BaseInput.ts
+++ b/app/components/shared/inputs/BaseInput.ts
@@ -24,6 +24,7 @@ export abstract class BaseInput<
   abstract readonly title: string;
   abstract readonly metadata: TMetadataType;
   onInput: Function = null;
+  onBlur: Function = null;
 
   /**
    * true if the component listens and re-emits child-inputs events
@@ -72,6 +73,14 @@ export abstract class BaseInput<
       (this.parentInput && !this.parentInput.delegateChildrenEvents);
 
     if (needToSendEventToForm) this.form.emitInput(eventData, event);
+  }
+
+  emitBlur(event?: any) {
+    this.$emit('blur', event);
+
+    if (this.onBlur) this.onBlur();
+
+    this.form.emitBlur(event);
   }
 
   getValidations() {

--- a/app/components/shared/inputs/NumberInput.vue
+++ b/app/components/shared/inputs/NumberInput.vue
@@ -14,6 +14,7 @@
       :value="displayValue"
       @input="handleInput($event.target.value)"
       @mousewheel="onMouseWheelHandler"
+      @blur="handleBlur"
       :name="options.uuid"
       v-validate="validate"
       :disabled="options.disabled"

--- a/app/components/shared/inputs/NumberInput.vue.ts
+++ b/app/components/shared/inputs/NumberInput.vue.ts
@@ -52,6 +52,10 @@ export default class NumberInput extends BaseInput<number | string, INumberMetad
     this.emitInput(value);
   }
 
+  handleBlur(event: Event) {
+    super.emitBlur(event);
+  }
+
   handleInput(value: string) {
     this.displayValue = value;
     if (value === '-' || value === '') return;

--- a/app/components/shared/inputs/ValidatedForm.tsx
+++ b/app/components/shared/inputs/ValidatedForm.tsx
@@ -16,6 +16,12 @@ class ValidatedFormProps {
    * 'input' event is triggering every time when nested field or nested form is changed
    */
   onInput?: () => unknown;
+
+  /**
+   * 'blur' event is triggering every time when nested field or nested form lost focus
+   */
+  onBlur?: (event: FocusEvent) => unknown;
+
   /**
    * A custom validation function that will be called after regular validation
    * Should return `true` for successful validation
@@ -101,6 +107,10 @@ export default class ValidatedForm extends TsxComponent<ValidatedFormProps> {
 
   emitInput(data: any, event: Event) {
     this.$emit('input', data, event);
+  }
+
+  async emitBlur(event: Event) {
+    this.$emit('blur', event);
   }
 
   handleSubmit(event: Event) {


### PR DESCRIPTION
Recover happens on focus lost. It restores the last valid value. This is essentially the same behavior as if user just closed the settings window.
I think it improves UX a lot, because:
- It is clear why value was changed
- Dialog stays always in a is usable state
I've also shown how this change relates to other behaviors like increasing values with scroll or empty values.
I personally do not like UX of empty values, but it is the same as in the current production version. I did not touch it.