### PR TITLE
fix(go-live): custom destinations aren't really persisted

### DIFF
--- a/app/components-react/windows/go-live/useGoLiveSettings.ts
+++ b/app/components-react/windows/go-live/useGoLiveSettings.ts
@@ -223,6 +223,11 @@ export class GoLiveSettingsModule {
     this.prepopulate();
   }
 
+  switchCustomDestination(destInd: number, enabled: boolean) {
+    this.state.switchCustomDestination(destInd, enabled);
+    this.save(this.state.settings);
+  }
+
   get enabledDestinations() {
     return this.state.customDestinations.reduce(
       (enabled: number[], dest: ICustomStreamDestination, index: number) => {


### PR DESCRIPTION
Custom destinations aren't really being persisted until we toggle a platform on or off (which saves settings), or (presumably) when going live. There's a call to `#save` after switching platforms but no such call exists for custom destinations. Adds a shadowing method (I know, but the same is used for `switchPlatforms` in some way it'd look like) that invokes the state update and saves right after.