### PR TITLE
fix(tiktok): proper window while streaming, other platform primary issue

### DIFF
--- a/app/components-react/root/LiveDock.tsx
+++ b/app/components-react/root/LiveDock.tsx
@@ -326,7 +326,8 @@ function LiveDock(p: { onLeft: boolean }) {
 
   const chat = useMemo(() => {
     const primaryChat = Services.UserService.state.auth!.primaryPlatform;
-    const showTiktokInfo = visibleChat === 'tiktok' || primaryChat === 'tiktok';
+    const showTiktokInfo =
+      visibleChat === 'tiktok' || (visibleChat === 'default' && primaryChat === 'tiktok');
 
     if (showTiktokInfo) {
       return <TikTokChatInfo />;

--- a/app/components-react/root/LiveDock.tsx
+++ b/app/components-react/root/LiveDock.tsx
@@ -328,7 +328,7 @@ function LiveDock(p: { onLeft: boolean }) {
     const primaryChat = Services.UserService.state.auth!.primaryPlatform;
     const showTiktokInfo = visibleChat === 'tiktok' || primaryChat === 'tiktok';
 
-    if (showTiktokInfo && !isRestreaming) {
+    if (showTiktokInfo) {
       return <TikTokChatInfo />;
     }
 


### PR DESCRIPTION
* We should be able to see the TikTok help window in chat as opposed to a blank window while streaming. 
* Switching between chat-supported platforms and Tiktok/Instagram should work now.
* Should no longer have a desync when Tiktok's primary chat, showing Twitch or other platform's chat on first open? 