### PR TITLE
Using unified volmeters callback instead of individual ones

### DIFF
--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -203,6 +203,7 @@ export class AppService extends StatefulService<IAppState> {
       await this.gameOverlayService.destroy();
       await this.fileManagerService.flushAll();
       obs.NodeObs.RemoveSourceCallback();
+      obs.NodeObs.RemoveVolmeterCallback();
       obs.NodeObs.OBS_service_removeCallback();
       obs.IPC.disconnect();
       this.crashReporterService.endShutdown();

--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -11,7 +11,6 @@ import { IAudioSource, IAudioSourceApi, IAudioSourcesState, IFader, IVolmeter } 
 import { EDeviceType, HardwareService, IDevice } from 'services/hardware';
 import { $t } from 'services/i18n';
 import { ipcMain, ipcRenderer } from 'electron';
-import without from 'lodash/without';
 import { ViewHandler } from 'services/core';
 
 export enum E_AUDIO_CHANNELS {
@@ -25,15 +24,20 @@ export enum E_AUDIO_CHANNELS {
 interface IAudioSourceData {
   fader?: obs.IFader;
   volmeter?: obs.IVolmeter;
-  callbackInfo?: obs.ICallbackData;
   stream?: Observable<IVolmeter>;
-  timeoutId?: number;
   isControlledViaObs?: boolean;
 }
 
 interface IVolmeterMessageChannel {
   id: string;
   port: MessagePort;
+}
+
+interface IObsVolmeterCallbackInfo {
+  sourceName: string;
+  magnitude: number[];
+  peak: number[];
+  inputPeak: number[];
 }
 
 class AudioViews extends ViewHandler<IAudioSourcesState> {
@@ -85,6 +89,10 @@ export class AudioService extends StatefulService<IAudioSourcesState> {
   }
 
   protected init() {
+    obs.NodeObs.RegisterVolmeterCallback((objs: IObsVolmeterCallbackInfo[]) =>
+      this.handleVolmeterCallback(objs),
+    );
+
     this.sourcesService.sourceAdded.subscribe(sourceModel => {
       const source = this.sourcesService.views.getSource(sourceModel.sourceId);
       if (!source.audio) return;
@@ -264,6 +272,19 @@ export class AudioService extends StatefulService<IAudioSourcesState> {
     this.audioSourceUpdated.next(this.state.audioSources[sourceId]);
   }
 
+  private handleVolmeterCallback(objs: IObsVolmeterCallbackInfo[]) {
+    objs.forEach(info => {
+      const source = this.views.getSource(info.sourceName);
+      // A source we don't care about
+      if (!source) {
+        return;
+      }
+
+      const volmeter: IVolmeter = info;
+      this.sendVolmeterData(info.sourceName, volmeter);
+    });
+  }
+
   private createAudioSource(source: Source) {
     this.sourceData[source.sourceId] = {};
 
@@ -275,45 +296,7 @@ export class AudioService extends StatefulService<IAudioSourcesState> {
     obsFader.attach(source.getObsInput());
     this.sourceData[source.sourceId].fader = obsFader;
 
-    this.initVolmeterStream(source.sourceId);
     this.ADD_AUDIO_SOURCE(this.generateAudioSourceData(source.sourceId));
-  }
-
-  private initVolmeterStream(sourceId: string) {
-    let gotEvent = false;
-    let lastVolmeterValue: IVolmeter;
-    this.sourceData[sourceId].callbackInfo = this.sourceData[sourceId].volmeter.addCallback(
-      (magnitude: number[], peak: number[], inputPeak: number[]) => {
-        const volmeter: IVolmeter = { magnitude, peak, inputPeak };
-
-        this.sendVolmeterData(sourceId, volmeter);
-        lastVolmeterValue = volmeter;
-        gotEvent = true;
-      },
-    );
-
-    /* This is useful for media sources since the volmeter will abruptly stop
-     * sending events in the case of hiding the source. It might be better
-     * to eventually just hide the mixer item as well though */
-    const volmeterCheck = () => {
-      if (!this.sourceData[sourceId]) return;
-
-      if (!gotEvent && lastVolmeterValue) {
-        const channelsCount = lastVolmeterValue.peak.length;
-        const channelsValue = Array(channelsCount).fill(-60);
-        this.sendVolmeterData(sourceId, {
-          ...lastVolmeterValue,
-          magnitude: channelsValue,
-          peak: channelsValue,
-          inputPeak: channelsValue,
-        });
-      }
-
-      gotEvent = false;
-      this.sourceData[sourceId].timeoutId = window.setTimeout(volmeterCheck, 100);
-    };
-
-    volmeterCheck();
   }
 
   private sendVolmeterData(sourceId: string, data: IVolmeter) {
@@ -325,10 +308,8 @@ export class AudioService extends StatefulService<IAudioSourcesState> {
   private removeAudioSource(sourceId: string) {
     this.sourceData[sourceId].fader.detach();
     this.sourceData[sourceId].fader.destroy();
-    this.sourceData[sourceId].volmeter.removeCallback(this.sourceData[sourceId].callbackInfo);
     this.sourceData[sourceId].volmeter.detach();
     this.sourceData[sourceId].volmeter.destroy();
-    if (this.sourceData[sourceId].timeoutId) clearTimeout(this.sourceData[sourceId].timeoutId);
     delete this.sourceData[sourceId];
     this.REMOVE_AUDIO_SOURCE(sourceId);
   }

--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,8 +4,8 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "0.25.1",
-      "mac_version": "0.24.43mb27",
+      "version": "0.25.3",
+      "mac_version": "0.25.3",
       "win64": true,
       "osx": true
     },


### PR DESCRIPTION
Attempt to increase performance and responsiveness of UI via aggregation of volmeters data into a single chunk and single call instead of bunch individuals calls.
This change actually unifies volmeters processing with sources processing.

As you may notice, I removed more code than added. Some logic was moved to back-end to make front-end life easier ;-)

PR in obs-studio-node:
https://github.com/stream-labs/obs-studio-node/pull/1476