### PR TITLE
Set default value to be same as used in a backend

### DIFF
--- a/app/components-react/windows/ScreenCaptureProperties.tsx
+++ b/app/components-react/windows/ScreenCaptureProperties.tsx
@@ -43,7 +43,7 @@ function useCaptureSource(sourceId: string): ICaptureSourceApi {
   const settings = useMemo(() => source.getSettings(), []);
   const [options, setOptions] = useState<ICapturableOption[]>([]);
   const [selectedOption, setSelectedOption] = useState<string>(settings['capture_source_list']);
-  const [captureCursor, setCaptureCursor] = useState(settings['capture_cursor']);
+  const [captureCursor, setCaptureCursor] = useState<boolean>(settings['capture_cursor'] ?? true);
 
   function buildSetter<TVal>(
     source: Source,


### PR DESCRIPTION
For other sources, we populate options window based on data obtained from OBS. 
The Screen Capture source is an exception, as it doesn't follow the same path and use a custom options window. it's necessary to explicitly set default values for the options.