### PR TITLE
Filter out preview alerts from mini feed (recent events)

### DIFF
--- a/app/services/recent-events.ts
+++ b/app/services/recent-events.ts
@@ -53,6 +53,7 @@ export interface IRecentEvent {
   read: boolean;
   hash: string;
   isTest?: boolean;
+  isPreview?: boolean;
   repeat?: boolean;
   // uuid is local and will NOT persist across app restarts/ fetches
   uuid: string;
@@ -884,7 +885,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
 
   onEventSocket(e: IEventSocketEvent) {
     const messages = e.message
-      .filter(msg => !msg.isTest && !msg.repeat)
+      .filter(msg => !msg.isTest && !msg.isPreview && !msg.repeat)
       .map(msg => {
         msg.platform = e.for;
         msg.type = e.type;


### PR DESCRIPTION
Asana Task: https://app.asana.com/0/1207748190451525/1208067331143655/f

From Alert Box Settings page (Streamlabs web Dashboard), when we click on "Preview" alert, the event appears on Desktop's mini feed and just disappears once the app is restarted.

Preview alerts should not be displayed in the Mini feed, but filtered out like the `isTest` alerts.