### PR TITLE
Hiding mixer item when source is not visible

### DIFF
--- a/app/components-react/editor/elements/Mixer.tsx
+++ b/app/components-react/editor/elements/Mixer.tsx
@@ -13,7 +13,7 @@ import { useRealmObject } from 'components-react/hooks/realm';
 const mins = { x: 150, y: 120 };
 
 export function Mixer() {
-  const { EditorCommandsService, AudioService, CustomizationService } = Services;
+  const { EditorCommandsService, AudioService, CustomizationService, ScenesService } = Services;
 
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -28,8 +28,12 @@ export function Mixer() {
   const performanceMode = useRealmObject(CustomizationService.state).performanceMode;
   const { audioSourceIds } = useVuex(() => ({
     audioSourceIds: AudioService.views.sourcesForCurrentScene
-      .filter(source => !source.mixerHidden && source.isControlledViaObs)
-      .map(source => source.sourceId),
+      .filter(source =>
+        !source.mixerHidden &&
+        source.isControlledViaObs &&
+        // If visibility state is undefined, such items will be displayed (for example, microphone)
+        ScenesService.views.activeScene?.getItems().find(item => item?.sourceId === source.sourceId)?.visible !== false
+      ).map(source => source.sourceId),
   }));
 
   function showAdvancedSettings() {

--- a/app/components-react/editor/elements/Mixer.tsx
+++ b/app/components-react/editor/elements/Mixer.tsx
@@ -31,8 +31,9 @@ export function Mixer() {
       .filter(source =>
         !source.mixerHidden &&
         source.isControlledViaObs &&
-        // If visibility state is undefined, such items will be displayed (for example, microphone)
-        ScenesService.views.activeScene?.getItems().find(item => item?.sourceId === source.sourceId)?.visible !== false
+        // Global audio sources like microphone are not present among active scene items
+        (ScenesService.views.activeScene?.getItems().filter(item => item?.sourceId === source.sourceId).length == 0 ||
+         ScenesService.views.activeScene?.getItems().filter(item => item?.sourceId === source.sourceId).some(e => e.visible !== false))
       ).map(source => source.sourceId),
   }));
 

--- a/app/components-react/editor/elements/mixer/GLVolmeters.tsx
+++ b/app/components-react/editor/elements/mixer/GLVolmeters.tsx
@@ -78,6 +78,7 @@ export default function GLVolmeters() {
 class GLVolmetersModule {
   private customizationService = Services.CustomizationService;
   private audioService = Services.AudioService;
+  private scenesService = Services.ScenesService
 
   subscriptions: Dictionary<IVolmeterSubscription> = {};
 
@@ -129,7 +130,10 @@ class GLVolmetersModule {
   // TODO: refactor into a single source of truth between Mixer and Volmeters
   get audioSources() {
     return this.audioService.views.sourcesForCurrentScene.filter(source => {
-      return !source.mixerHidden && source.isControlledViaObs;
+      return !source.mixerHidden &&
+             source.isControlledViaObs &&
+             // If visibility state is undefined, such items will be displayed (for example, microphone)
+             this.scenesService.views.activeScene?.getItems().find(item => item?.sourceId === source.sourceId)?.visible !== false
     });
   }
 

--- a/app/components-react/editor/elements/mixer/GLVolmeters.tsx
+++ b/app/components-react/editor/elements/mixer/GLVolmeters.tsx
@@ -132,8 +132,9 @@ class GLVolmetersModule {
     return this.audioService.views.sourcesForCurrentScene.filter(source => {
       return !source.mixerHidden &&
              source.isControlledViaObs &&
-             // If visibility state is undefined, such items will be displayed (for example, microphone)
-             this.scenesService.views.activeScene?.getItems().find(item => item?.sourceId === source.sourceId)?.visible !== false
+             // Global audio sources like microphone are not present among active scene items
+             (this.scenesService.views.activeScene?.getItems().filter(item => item?.sourceId === source.sourceId).length == 0 ||
+              this.scenesService.views.activeScene?.getItems().filter(item => item?.sourceId === source.sourceId).some(e => e.visible !== false))
     });
   }
 

--- a/app/components-react/editor/elements/mixer/GLVolmeters.tsx
+++ b/app/components-react/editor/elements/mixer/GLVolmeters.tsx
@@ -86,6 +86,9 @@ class GLVolmetersModule {
   private gl: WebGLRenderingContext;
   private program: WebGLProgram;
 
+  // As we limit FPS, force redraw is needed to avoid flickering when sources are updated/removed/deleted
+  private forceRedraw:boolean;
+
   // GL Attribute locations
   private positionLocation: number;
 
@@ -149,6 +152,7 @@ class GLVolmetersModule {
    */
 
   private subscribeVolmeters() {
+    this.forceRedraw = true;
     const audioSources = this.audioSources;
     const sourcesOrder = audioSources.map(source => source.sourceId);
 
@@ -267,7 +271,8 @@ class GLVolmetersModule {
     const timeBetweenFrames = 1000 / this.fpsLimit;
     const currentFrameNumber = Math.ceil(timeElapsed / timeBetweenFrames);
 
-    if (currentFrameNumber !== this.frameNumber) {
+    if (currentFrameNumber !== this.frameNumber || this.forceRedraw) {
+      this.forceRedraw = false;
       // it's time to render next frame
       this.frameNumber = currentFrameNumber;
       // don't render sources then channelsCount is 0


### PR DESCRIPTION
This change is done to unify behavior with OBS which hides sources in mixer when source is not visible on scene.
Note: this branch was created from the `master`.