### PR TITLE
feat: add collectibles API for adding source inside embed

### DIFF
--- a/app/components-react/pages/BrowseOverlays.tsx
+++ b/app/components-react/pages/BrowseOverlays.tsx
@@ -130,8 +130,10 @@ export default function BrowseOverlays(p: {
     }
 
     if (
-      !assetURL.startsWith('https://cdn.streamlabs.com/marketplace') ||
-      !assetURL.startsWith('https://streamlabs-marketplace-staging.streamlabs.com')
+      !(
+        assetURL.startsWith('https://cdn.streamlabs.com/marketplace') ||
+        assetURL.startsWith('https://streamlabs-marketplace-staging.streamlabs.com')
+      )
     ) {
       throw new Error('Invalid asset URL');
     }

--- a/app/components-react/pages/BrowseOverlays.tsx
+++ b/app/components-react/pages/BrowseOverlays.tsx
@@ -114,6 +114,7 @@ export default function BrowseOverlays(p: {
    * Collectibles are just a CDN URL of an image or video, this API provides
    * embedded pages with a convenience method for creating sources based on those.
    *
+   * @param name - Name of the collectible, used as source name
    * @param sceneId - ID of the scene where the collectible will be added to
    * @param assetURL - CDN URL of the collectible asset
    * @param type - Type of source that will be created, `image` or `video`
@@ -124,7 +125,12 @@ export default function BrowseOverlays(p: {
    * @throws When scene for the provided scene ID can't be found.
    * @throws When it fails to create the source.
    */
-  async function addCollectibleToScene(sceneId: string, assetURL: string, type: 'image' | 'video') {
+  async function addCollectibleToScene(
+    name: string,
+    sceneId: string,
+    assetURL: string,
+    type: 'image' | 'video',
+  ) {
     if (!['image', 'video'].includes(type)) {
       throw new Error("Unsupported type. Use 'image' or 'video'");
     }
@@ -145,7 +151,7 @@ export default function BrowseOverlays(p: {
     const sourceType = type === 'video' ? 'ffmpeg_source' : 'image_source';
 
     // TODO: do we want the caller to provide name?
-    const sourceName = SourcesService.views.suggestName('Collectible');
+    const sourceName = name;
 
     return ScenesService.actions.return.createAndAddSource(
       sceneId,

--- a/app/components-react/pages/BrowseOverlays.tsx
+++ b/app/components-react/pages/BrowseOverlays.tsx
@@ -153,6 +153,11 @@ export default function BrowseOverlays(p: {
     const sourceName = name;
 
     const filename = path.basename(assetURL);
+
+    // On a fresh cache with login and not restarting the app this
+    // directory might not exist, based on testing
+    await MediaBackupService.actions.return.ensureMediaDirectory();
+
     const dest = path.join(MediaBackupService.mediaDirectory, filename);
 
     // TODO: refactor all this

--- a/app/components-react/pages/BrowseOverlays.tsx
+++ b/app/components-react/pages/BrowseOverlays.tsx
@@ -139,10 +139,10 @@ export default function BrowseOverlays(p: {
     }
 
     if (
-      !(
-        assetURL.startsWith('https://cdn.streamlabs.com/marketplace') ||
-        assetURL.startsWith('https://streamlabs-marketplace-staging.streamlabs.com')
-      )
+      !hasValidHost(assetURL, [
+        'cdn.streamlabs.com',
+        'streamlabs-marketplace-staging.streamlabs.com',
+      ])
     ) {
       throw new Error('Invalid asset URL');
     }
@@ -177,6 +177,11 @@ export default function BrowseOverlays(p: {
     );
   }
 
+  function hasValidHost(url: string, trustedHosts: string[]) {
+    const host = new urlLib.URL(url).hostname;
+    return trustedHosts.includes(host);
+  }
+
   async function installOverlayBase(
     url: string,
     name: string,
@@ -184,6 +189,7 @@ export default function BrowseOverlays(p: {
     mergePlatform = false,
   ) {
     return new Promise<void>((resolve, reject) => {
+      // TODO: refactor to use hasValidHost
       const host = new urlLib.URL(url).hostname;
       const trustedHosts = ['cdn.streamlabs.com'];
       if (!trustedHosts.includes(host)) {

--- a/app/components-react/pages/BrowseOverlays.tsx
+++ b/app/components-react/pages/BrowseOverlays.tsx
@@ -104,6 +104,7 @@ export default function BrowseOverlays(p: {
     return ScenesService.views.scenes.map(scene => ({
       id: scene.id,
       name: scene.name,
+      isActiveScene: scene.id === ScenesService.views.activeSceneId,
     }));
   }
 

--- a/app/components-react/pages/BrowseOverlays.tsx
+++ b/app/components-react/pages/BrowseOverlays.tsx
@@ -129,7 +129,10 @@ export default function BrowseOverlays(p: {
       throw new Error("Unsupported type. Use 'image' or 'video'");
     }
 
-    if (!assetURL.startsWith('https://cdn.streamlabs.com/marketplace')) {
+    if (
+      !assetURL.startsWith('https://cdn.streamlabs.com/marketplace') ||
+      !assetURL.startsWith('https://streamlabs-marketplace-staging.streamlabs.com')
+    ) {
       throw new Error('Invalid asset URL');
     }
 

--- a/app/components-react/pages/BrowseOverlays.tsx
+++ b/app/components-react/pages/BrowseOverlays.tsx
@@ -25,8 +25,6 @@ export default function BrowseOverlays(p: {
     NotificationsService,
     JsonrpcService,
     RestreamService,
-    // TODO: we're grabbing this just to suggest name
-    SourcesService,
     MediaBackupService,
   } = Services;
   const [downloading, setDownloading] = useState(false);
@@ -124,6 +122,11 @@ export default function BrowseOverlays(p: {
    * @throws When URL is a not a Streamlabs CDN URL.
    * @throws When scene for the provided scene ID can't be found.
    * @throws When it fails to create the source.
+   *
+   * @remarks When using a gif, the type should be set to `video` due to some
+   * inconsistencies we found with image source, namely around playback being
+   * shoppy or sometimes not displaying at all. Granted, we tested remote files
+   * at the start, so this might not be true for local files which are now downloaded.
    */
   async function addCollectibleToScene(
     name: string,
@@ -147,14 +150,13 @@ export default function BrowseOverlays(p: {
     // TODO: find or create enum
     const sourceType = type === 'video' ? 'ffmpeg_source' : 'image_source';
 
-    // TODO: do we want the caller to provide name?
     const sourceName = name;
 
     const filename = path.basename(assetURL);
     const dest = path.join(MediaBackupService.mediaDirectory, filename);
 
     // TODO: refactor all this
-    // TODO: media backup
+    // TODO: test if media backup is working automatically or we need changes
     let localFile;
 
     try {
@@ -163,8 +165,6 @@ export default function BrowseOverlays(p: {
     } catch {
       throw new Error('Error downloading file to local system');
     }
-
-    console.log('File downloaded');
 
     const sourceSettings =
       type === 'video' ? { looping: true, local_file: localFile } : { file: localFile };

--- a/app/services/media-backup.ts
+++ b/app/services/media-backup.ts
@@ -325,7 +325,7 @@ export class MediaBackupService extends StatefulService<IMediaBackupState> {
     }
   }
 
-  private get mediaDirectory() {
+  get mediaDirectory() {
     return path.join(this.appService.appDataDirectory, 'Media');
   }
 

--- a/app/services/media-backup.ts
+++ b/app/services/media-backup.ts
@@ -319,7 +319,7 @@ export class MediaBackupService extends StatefulService<IMediaBackupState> {
     return { Authorization: `Bearer ${this.userService.apiToken}` };
   }
 
-  private ensureMediaDirectory() {
+  ensureMediaDirectory() {
     if (!fs.existsSync(this.mediaDirectory)) {
       fs.mkdirSync(this.mediaDirectory);
     }

--- a/app/services/scenes/scenes.ts
+++ b/app/services/scenes/scenes.ts
@@ -452,7 +452,12 @@ export class ScenesService extends StatefulService<IScenesState> {
     if (!scene) {
       throw new Error(`Can't find scene with ID: ${sceneId}`);
     }
-    return scene.createAndAddSource(sourceName, sourceType, settings).sceneItemId;
+
+    const sceneItem = scene.createAndAddSource(sourceName, sourceType, settings);
+
+    this.dualOutputService.createPartnerNode(sceneItem);
+
+    return sceneItem.sceneItemId;
   }
 
   // TODO: Remove all of this in favor of the new "views" methods

--- a/app/services/scenes/scenes.ts
+++ b/app/services/scenes/scenes.ts
@@ -13,7 +13,7 @@ import namingHelpers from 'util/NamingHelpers';
 import uuid from 'uuid/v4';
 import { DualOutputService } from 'services/dual-output';
 import { TDisplayType } from 'services/settings-v2/video';
-import { InitAfter, ViewHandler } from 'services/core';
+import { ExecuteInWorkerProcess, InitAfter, ViewHandler } from 'services/core';
 
 export type TSceneNodeModel = ISceneItem | ISceneItemFolder;
 
@@ -266,6 +266,16 @@ class ScenesViews extends ViewHandler<IScenesState> {
 
     return false;
   }
+
+  createAndAddSource(
+    sceneId: string,
+    name: string,
+    sourceType: TSourceType,
+    settings: Dictionary<any>,
+  ) {
+    const scene = this.getScene(sceneId);
+    return scene?.createAndAddSource(name, sourceType, settings).sceneItemId;
+  }
 }
 
 @InitAfter('DualOutputService')
@@ -440,6 +450,15 @@ export class ScenesService extends StatefulService<IScenesState> {
 
   getModel(): IScenesState {
     return this.state;
+  }
+
+  createAndAddSource(
+    sceneId: string,
+    sourceName: string,
+    sourceType: TSourceType,
+    settings: Dictionary<unknown>,
+  ) {
+    return this.views.createAndAddSource(sceneId, sourceName, sourceType, settings);
   }
 
   // TODO: Remove all of this in favor of the new "views" methods

--- a/app/services/scenes/scenes.ts
+++ b/app/services/scenes/scenes.ts
@@ -266,16 +266,6 @@ class ScenesViews extends ViewHandler<IScenesState> {
 
     return false;
   }
-
-  createAndAddSource(
-    sceneId: string,
-    name: string,
-    sourceType: TSourceType,
-    settings: Dictionary<any>,
-  ) {
-    const scene = this.getScene(sceneId);
-    return scene?.createAndAddSource(name, sourceType, settings).sceneItemId;
-  }
 }
 
 @InitAfter('DualOutputService')
@@ -458,7 +448,11 @@ export class ScenesService extends StatefulService<IScenesState> {
     sourceType: TSourceType,
     settings: Dictionary<unknown>,
   ) {
-    return this.views.createAndAddSource(sceneId, sourceName, sourceType, settings);
+    const scene = this.views.getScene(sceneId);
+    if (!scene) {
+      throw new Error(`Can't find scene with ID: ${sceneId}`);
+    }
+    return scene.createAndAddSource(sourceName, sourceType, settings).sceneItemId;
   }
 
   // TODO: Remove all of this in favor of the new "views" methods


### PR DESCRIPTION
Adds guest API methods for listing scenes and adding a collectible to a specific scene. This is convenience for create source depending on its type.