### PR TITLE
feat(build): convenience for packaging build for beta, details follow

### DIFF
--- a/app/services/utils.ts
+++ b/app/services/utils.ts
@@ -114,7 +114,7 @@ export default class Utils {
   }
 
   static shouldUseBeta(): boolean {
-    return Utils.env.SLD_USE_BETA as boolean;
+    return (process.env.SLD_COMPILE_FOR_BETA || Utils.env.SLD_USE_BETA) as boolean;
   }
 
   /**

--- a/electron-builder/beta.config.js
+++ b/electron-builder/beta.config.js
@@ -1,0 +1,9 @@
+const base = require('./base.config');
+
+base.win.extraFiles.push({
+  from: 'electron-builder/force-local-bundles',
+  to: 'force-local-bundles',
+});
+base.win.executableName = 'Streamlabs OBS for Beta';
+
+module.exports = base;

--- a/electron-builder/force-local-bundles
+++ b/electron-builder/force-local-bundles
@@ -1,0 +1,2 @@
+This does nothing, the presence of this file means the updater for beta build
+will use local bundles.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "package:mac": "yarn generate-agreement:mac && rimraf dist && electron-builder build -m --x64 --config electron-builder/base.config.js",
     "package:mac-arm64": "yarn generate-agreement:mac && rimraf dist && electron-builder build -m --arm64 --config electron-builder/base.config.js",
     "package:preview": "yarn generate-agreement && rimraf dist && electron-builder build -w --x64 --config electron-builder/preview.config.js",
+    "package:beta": "cross-env SLD_COMPILE_FOR_BETA=1 yarn compile && yarn generate-agreement && rimraf dist && electron-builder build -w --x64 --config electron-builder/beta.config.js",
     "eslint": "eslint \"{app,guest-api,obs-api,updater}/**/*.ts\" main.js",
     "test": "tsc -p test && ava -v --timeout=3m ./test-dist/test/regular/**/*.js",
     "test:file": "tsc -p test && ava -v --timeout=60m",

--- a/updater/bundle-updater.ts
+++ b/updater/bundle-updater.ts
@@ -299,6 +299,11 @@ module.exports = async (basePath: string) => {
     useLocalBundles = true;
   }
 
+  const forceLocalBundles = path.join(basePath, '../../force-local-bundles');
+  if (fs.existsSync(forceLocalBundles)) {
+    useLocalBundles = true;
+  }
+
   const localManifest: IManifest = require(path.join(`${basePath}/bundles/manifest.json`));
 
   console.log('Local bundle info:', localManifest);

--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -10,16 +10,21 @@ const plugins = [];
 
 const commit = cp.execSync('git rev-parse --short HEAD').toString().replace('\n', '');
 
-plugins.push(
-  new webpack.DefinePlugin({
-    SLOBS_BUNDLE_ID: JSON.stringify(commit),
-    SLD_SENTRY_FRONTEND_DSN: JSON.stringify(process.env.SLD_SENTRY_FRONTEND_DSN ?? ''),
-    SLD_SENTRY_BACKEND_SERVER_URL: JSON.stringify(process.env.SLD_SENTRY_BACKEND_SERVER_URL ?? ''),
-    SLD_SENTRY_BACKEND_SERVER_PREVIEW_URL: JSON.stringify(
-      process.env.SLD_SENTRY_BACKEND_SERVER_PREVIEW_URL ?? '',
-    ),
-  }),
-);
+const envDef = {
+  SLOBS_BUNDLE_ID: JSON.stringify(commit),
+  SLD_SENTRY_FRONTEND_DSN: JSON.stringify(process.env.SLD_SENTRY_FRONTEND_DSN ?? ''),
+  SLD_SENTRY_BACKEND_SERVER_URL: JSON.stringify(process.env.SLD_SENTRY_BACKEND_SERVER_URL ?? ''),
+  SLD_SENTRY_BACKEND_SERVER_PREVIEW_URL: JSON.stringify(
+    process.env.SLD_SENTRY_BACKEND_SERVER_PREVIEW_URL ?? '',
+  ),
+};
+
+if (process.env.SLD_COMPILE_FOR_BETA) {
+  console.log('Compiling build with forced beta SL host.');
+  envDef['process.env.SLD_COMPILE_FOR_BETA'] = JSON.stringify(true);
+}
+
+plugins.push(new webpack.DefinePlugin(envDef));
 
 plugins.push(
   new WebpackManifestPlugin({


### PR DESCRIPTION
Use `yarn package:beta` to package an app build pointing to beta.

* Does not require modifying code anymore.
* Does not require user intervention (i.e. setting env vars before running the app).
* Executable name is renamed to "Streamlabs OBS for Beta".
* Forces local bundles, without it your development branch would likely be overwritten by the updater using remote bundles.
* Compiles in development mode so that compilation is faster and we can troubleshoot non-minified logs.
* Tested on Windows, Mac PR welcome :)