### PR TITLE
fix(collectibles): only create partner nodes if dual output enabled

### DIFF
--- a/app/services/dual-output/dual-output.ts
+++ b/app/services/dual-output/dual-output.ts
@@ -330,6 +330,7 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
 
   sceneNodeHandled = new Subject<number>();
   collectionHandled = new Subject<{ [sceneId: string]: Dictionary<string> } | null>();
+  dualOutputModeChanged = new Subject<boolean>();
 
   get views() {
     return new DualOutputViews(this.state);
@@ -427,6 +428,7 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
     }
 
     this.SET_IS_LOADING(false);
+    this.dualOutputModeChanged.next(status);
   }
 
   disableGlobalRescaleIfNeeded() {

--- a/app/services/scenes/scenes.ts
+++ b/app/services/scenes/scenes.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import without from 'lodash/without';
 import { Subject } from 'rxjs';
-import { filter, take, tap } from 'rxjs/operators';
+import { filter, take, takeUntil, tap } from 'rxjs/operators';
 import { mutation, StatefulService } from 'services/core/stateful-service';
 import { TransitionsService } from 'services/transitions';
 import { WindowsService } from 'services/windows';
@@ -13,6 +13,7 @@ import { $t } from 'services/i18n';
 import namingHelpers from 'util/NamingHelpers';
 import uuid from 'uuid/v4';
 import { DualOutputService } from 'services/dual-output';
+import { SceneCollectionsService } from 'services/scene-collections';
 import { TDisplayType } from 'services/settings-v2/video';
 import { ExecuteInWorkerProcess, InitAfter, ViewHandler } from 'services/core';
 
@@ -272,6 +273,7 @@ class ScenesViews extends ViewHandler<IScenesState> {
 @InitAfter('DualOutputService')
 export class ScenesService extends StatefulService<IScenesState> {
   @Inject() private dualOutputService: DualOutputService;
+  @Inject() private sceneCollectionsService: SceneCollectionsService;
 
   static initialState: IScenesState = {
     activeSceneId: '',
@@ -464,6 +466,9 @@ export class ScenesService extends StatefulService<IScenesState> {
       // Schedule vertical node to be created if the user toggles on dual output in the same session
       this.dualOutputService.dualOutputModeChanged
         .pipe(
+          // If we switch collections before we enable dual output drop it
+          // we don't wanna create nodes on inactive scene collections
+          takeUntil(this.sceneCollectionsService.collectionWillSwitch),
           filter(gotEnabled => !!gotEnabled),
           take(1),
           tap(createVerticalNode),

--- a/app/services/scenes/scenes.ts
+++ b/app/services/scenes/scenes.ts
@@ -455,7 +455,9 @@ export class ScenesService extends StatefulService<IScenesState> {
 
     const sceneItem = scene.createAndAddSource(sourceName, sourceType, settings);
 
-    this.dualOutputService.createPartnerNode(sceneItem);
+    if (this.dualOutputService.state.dualOutputMode) {
+      this.dualOutputService.createPartnerNode(sceneItem);
+    }
 
     return sceneItem.sceneItemId;
   }


### PR DESCRIPTION
Unconditionally creating partner nodes when dual output is disabled makes the source appear twice in the editor, due to that vertical node being created. Side effect of this is that if the user adds a collectible and only then enables dual output, they'll probably have to wait till a full app launch for it to show on the vertical display.