### PR TITLE
feat(nav): versioning and collectibles

### DIFF
--- a/app/i18n/en-US/common.json
+++ b/app/i18n/en-US/common.json
@@ -159,7 +159,7 @@
   "Alert Box": "Alert Box",
   "Widget": "Widget",
   "Creator Sites": "Creator Sites",
-  "Collectibles (Beta)": "Collectibles (Beta)",
+  "Collectibles": "Collectibles",
   "Apps Manager": "Apps Manager",
   "Theme Audit": "Theme Audit",
   "Login": "Login",

--- a/app/i18n/en-US/common.json
+++ b/app/i18n/en-US/common.json
@@ -159,6 +159,7 @@
   "Alert Box": "Alert Box",
   "Widget": "Widget",
   "Creator Sites": "Creator Sites",
+  "Collectibles (Beta)": "Collectibles (Beta)",
   "Apps Manager": "Apps Manager",
   "Theme Audit": "Theme Audit",
   "Login": "Login",

--- a/app/services/side-nav/menu-data.ts
+++ b/app/services/side-nav/menu-data.ts
@@ -151,7 +151,7 @@ export const menuTitles = (item: EMenuItemKey | ESubMenuItemKey | string) => {
     [ESubMenuItemKey.Scene]: $t('Scene'),
     [ESubMenuItemKey.Widget]: $t('Alerts and Widgets'),
     [ESubMenuItemKey.Sites]: $t('Creator Sites'),
-    [ESubMenuItemKey.Collectibles]: $t('Collectibles (Beta)'),
+    [ESubMenuItemKey.Collectibles]: $t('Collectibles'),
     [ESubMenuItemKey.AppsStoreHome]: $t('Apps Store Home'),
     [ESubMenuItemKey.AppsManager]: $t('Apps Manager'),
     [ESubMenuItemKey.DashboardHome]: $t('Dashboard Home'),

--- a/app/services/side-nav/menu-data.ts
+++ b/app/services/side-nav/menu-data.ts
@@ -38,6 +38,7 @@ export enum ESubMenuItemKey {
   Scene = 'browse-overlays',
   Widget = 'browse-overlays-widgets',
   Sites = 'browse-overlays-sites',
+  Collectibles = 'browse-overlays-collectibles',
   AppsStoreHome = 'platform-app-store-home',
   AppsManager = 'platform-app-store-manager',
   DashboardHome = 'dashboard-home',
@@ -150,6 +151,7 @@ export const menuTitles = (item: EMenuItemKey | ESubMenuItemKey | string) => {
     [ESubMenuItemKey.Scene]: $t('Scene'),
     [ESubMenuItemKey.Widget]: $t('Alerts and Widgets'),
     [ESubMenuItemKey.Sites]: $t('Creator Sites'),
+    [ESubMenuItemKey.Collectibles]: $t('Collectibles (Beta)'),
     [ESubMenuItemKey.AppsStoreHome]: $t('Apps Store Home'),
     [ESubMenuItemKey.AppsManager]: $t('Apps Manager'),
     [ESubMenuItemKey.DashboardHome]: $t('Dashboard Home'),
@@ -231,7 +233,7 @@ export const SideNavMenuItems = (): TMenuItems => ({
     subMenuItems: [
       SideBarSubMenuItems()[ESubMenuItemKey.Scene],
       SideBarSubMenuItems()[ESubMenuItemKey.Widget],
-      SideBarSubMenuItems()[ESubMenuItemKey.Sites],
+      SideBarSubMenuItems()[ESubMenuItemKey.Collectibles],
     ],
     isActive: true,
     isExpanded: false,
@@ -346,6 +348,13 @@ export const SideBarSubMenuItems = (): TSubMenuItems => ({
     type: 'site-themes',
     trackingTarget: 'themes',
     isActive: false,
+    isExpanded: false,
+  },
+  [ESubMenuItemKey.Collectibles]: {
+    key: ESubMenuItemKey.Collectibles,
+    target: 'BrowseOverlays',
+    type: 'collectibles',
+    trackingTarget: 'themes',
     isExpanded: false,
   },
   [ESubMenuItemKey.AppsStoreHome]: {

--- a/app/services/user/index.ts
+++ b/app/services/user/index.ts
@@ -931,7 +931,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
   }
 
   async overlaysUrl(
-    type?: 'overlay' | 'widget-themes' | 'site-themes',
+    type?: 'overlay' | 'widget-themes' | 'site-themes' | 'collectibles',
     id?: string,
     install?: string,
   ) {


### PR DESCRIPTION
* Allow persistence versioning on side nav items, without it items on the sidebar get loaded from local storage without respecting what's in code until a cache reset or worse.
* This also removes the need for the workaround we had for Alert Box Library.
* Replaces Creator Sites with Collectibles. 