### PR TITLE
fix(game-capture): capture overlays reverts on node load

### DIFF
--- a/app/services/scene-collections/nodes/overlays/game-capture.ts
+++ b/app/services/scene-collections/nodes/overlays/game-capture.ts
@@ -51,10 +51,6 @@ export class GameCaptureNode extends Node<ISchema, IContext> {
   async load(context: IContext) {
     // A custom placeholder is not always provided
     if (!this.data.placeholderFile) {
-      // always capture overlays by default
-      context.sceneItem.getObsInput().update({
-        capture_overlays: true,
-      });
       return;
     }
 
@@ -62,7 +58,6 @@ export class GameCaptureNode extends Node<ISchema, IContext> {
     context.sceneItem.getObsInput().update({
       user_placeholder_image: filePath,
       user_placeholder_use: true,
-      capture_overlays: true,
     });
 
     // This is a bit of a hack to force us to immediately back up

--- a/app/services/sources/properties-managers/default-manager.ts
+++ b/app/services/sources/properties-managers/default-manager.ts
@@ -181,7 +181,7 @@ export class DefaultManager extends PropertiesManager {
       window_placeholder_image: getSharedResource('capture-placeholder.png'),
       window_placeholder_waiting_message: $t('Looking for a game to capture'),
       window_placeholder_missing_message: $t('Specified window is not a game'),
-      capture_overlays: true,
+      capture_overlays: this.obsSource.settings.capture_overlays ?? true,
     });
   }
 }


### PR DESCRIPTION
We were unconditionally enabling capture overlays option when loading a `GameCaptureNode`. This commit removes these calls and makes sure that for the property manager init the initialization respect whether a previous setting exists.