### PR TITLE
feat(widgets): new ChatBox API and first setting, details follow

### DIFF
--- a/app/components-react/widgets/ChatBox.tsx
+++ b/app/components-react/widgets/ChatBox.tsx
@@ -45,7 +45,7 @@ export function ChatBox() {
 
 export class ChatBoxModule extends WidgetModule<IChatBoxState> {
   get meta() {
-    return {
+    const result = {
       theme: metadata.list({
         label: $t('Theme'),
         options: [
@@ -111,15 +111,44 @@ export class ChatBoxModule extends WidgetModule<IChatBoxState> {
       },
       muted_chatters: metadata.textarea({ label: $t('Muted Chatters') }),
     };
+
+    if (this.config.useNewWidgetAPI) {
+      return {
+        ...result,
+        alert_enabled: metadata.switch({
+          label: $t('Chat Notifications'),
+          tooltip: $t('Trigger a sound to notify you when there is new chat activity'),
+        }),
+      };
+    }
+
+    return result;
+  }
+
+  // TODO: move these to widget module in a more generic way
+  protected patchAfterFetch(resp: any) {
+    if (this.config.useNewWidgetAPI) {
+      const data = {
+        settings: resp.data.settings.global,
+      };
+
+      return data;
+    }
+
+    return resp;
   }
 
   // The server sends and recieves these duration fields at different precision
   protected patchBeforeSend(settings: IChatBoxState['data']['settings']) {
-    return {
+    const obj = {
       ...settings,
       message_hide_delay: Math.floor(settings.message_hide_delay / 1000),
       message_show_delay: Math.floor(settings.message_show_delay / 1000),
     };
+
+    if (this.config.useNewWidgetAPI) {
+      return { global: obj };
+    }
   }
 }
 

--- a/app/components-react/widgets/common/useWidget.tsx
+++ b/app/components-react/widgets/common/useWidget.tsx
@@ -252,11 +252,13 @@ export class WidgetModule<TWidgetState extends IWidgetState = IWidgetState> {
   @throttle(500)
   private async saveSettings(settings: TWidgetState['data']['settings']) {
     const body = this.patchBeforeSend(settings);
+    const method = this.config.useNewWidgetAPI ? 'PUT' : 'POST';
+
     try {
       return await this.actions.return.request({
         body,
+        method,
         url: this.config.settingsSaveUrl,
-        method: 'POST',
       });
     } catch (e: unknown) {
       await alertAsync({

--- a/app/i18n/en-US/widget-chat-box.json
+++ b/app/i18n/en-US/widget-chat-box.json
@@ -26,5 +26,7 @@
   "Disable Message Animations": "Disable Message Animations",
   "Hide Characters": "Hide Characters",
   "Hide Common Chat Bots": "Hide Common Chat Bots",
-  "Hide commands starting with `!`": "Hide commands starting with `!`"
+  "Hide commands starting with `!`": "Hide commands starting with `!`",
+  "Chat Notifications": "Chat Notifications",
+  "Trigger a sound to notify you when there is new chat activity": "Trigger a sound to notify you when there is new chat activity"
 }

--- a/app/services/incremental-rollout.ts
+++ b/app/services/incremental-rollout.ts
@@ -27,6 +27,7 @@ export enum EAvailableFeatures {
    */
   guestCamBeta = 'slobs--guest-join',
   guestCamProduction = 'slobs--guest-join-prod',
+  newChatBox = 'core--widgets-v2--chat-box',
 }
 
 interface IIncrementalRolloutServiceState {

--- a/app/services/widgets/settings/widget-settings.ts
+++ b/app/services/widgets/settings/widget-settings.ts
@@ -25,7 +25,7 @@ export const WIDGET_INITIAL_STATE: IWidgetSettingsGenericState = {
   pendingRequests: 0,
 };
 
-export type THttpMethod = 'GET' | 'POST' | 'DELETE';
+export type THttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
 interface ISocketEvent {
   type: string;

--- a/app/services/widgets/widgets-config.ts
+++ b/app/services/widgets/widgets-config.ts
@@ -14,6 +14,9 @@ export type TWidgetType =
 export interface IWidgetConfig {
   type: TWidgetType;
 
+  /** Wether this widget uses the new widget API at `/api/v5/widgets/desktop/...` **/
+  useNewWidgetAPI?: boolean;
+
   // Default transform for the widget
   defaultTransform: {
     width: number;
@@ -45,7 +48,11 @@ export interface IWidgetConfig {
   };
 }
 
-export function getWidgetsConfig(host: string, token: string): Record<TWidgetType, IWidgetConfig> {
+export function getWidgetsConfig(
+  host: string,
+  token: string,
+  widgetsWithNewAPI: WidgetType[] = [],
+): Record<TWidgetType, IWidgetConfig> {
   return {
     [WidgetType.AlertBox]: {
       type: WidgetType.AlertBox,
@@ -192,13 +199,23 @@ export function getWidgetsConfig(host: string, token: string): Record<TWidgetTyp
         height: 700,
       },
 
-      url: `https://${host}/widgets/chat-box/v1/${token}`,
-      previewUrl: `https://${host}/widgets/chat-box/v1/${token}?simulate=1`,
-      dataFetchUrl: `https://${host}/api/v5/slobs/widget/chatbox`,
-      settingsSaveUrl: `https://${host}/api/v5/slobs/widget/chatbox`,
       settingsUpdateEvent: 'chatBoxSettingsUpdate',
       customCodeAllowed: true,
       customFieldsAllowed: true,
+      url: `https://${host}/widgets/chat-box/v1/${token}`,
+      previewUrl: `https://${host}/widgets/chat-box/v1/${token}?simulate=1`,
+
+      ...(widgetsWithNewAPI.includes(WidgetType.ChatBox)
+        ? {
+            // TODO: extra boolean tracking, move to method
+            useNewWidgetAPI: true,
+            dataFetchUrl: `https://${host}/api/v5/widgets/desktop/chat-box`,
+            settingsSaveUrl: `https://${host}/api/v5/widgets/desktop/chat-box`,
+          }
+        : {
+            dataFetchUrl: `https://${host}/api/v5/slobs/widget/chatbox`,
+            settingsSaveUrl: `https://${host}/api/v5/slobs/widget/chatbox`,
+          }),
     },
 
     // ChatHighlight: {

--- a/app/services/widgets/widgets.ts
+++ b/app/services/widgets/widgets.ts
@@ -26,6 +26,8 @@ import { getWidgetsConfig } from './widgets-config';
 import { WidgetDisplayData } from '.';
 import { DualOutputService } from 'services/dual-output';
 import { TDisplayType, VideoSettingsService } from 'services/settings-v2';
+import { IncrementalRolloutService } from 'app-services';
+import { EAvailableFeatures } from 'services/incremental-rollout';
 
 export interface IWidgetSourcesState {
   widgetSources: Dictionary<IWidgetSource>;
@@ -83,6 +85,7 @@ export class WidgetsService
   @Inject() editorCommandsService: EditorCommandsService;
   @Inject() dualOutputService: DualOutputService;
   @Inject() videoSettingsService: VideoSettingsService;
+  @Inject() incrementalRolloutService: IncrementalRolloutService;
 
   widgetDisplayData = WidgetDisplayData(); // cache widget display data
 
@@ -448,7 +451,19 @@ export class WidgetsService
   }
 
   get widgetsConfig() {
-    return getWidgetsConfig(this.hostsService.streamlabs, this.userService.widgetToken);
+    // Widgets that have been ported to the new backend API at /api/v5/widgets/desktop
+    const widgetsWithNewAPI: WidgetType[] = [];
+
+    // The new chatbox requires the new widget API, add it here if the user is under incremental
+    if (this.incrementalRolloutService.views.featureIsEnabled(EAvailableFeatures.newChatBox)) {
+      widgetsWithNewAPI.push(WidgetType.ChatBox);
+    }
+
+    return getWidgetsConfig(
+      this.hostsService.streamlabs,
+      this.userService.widgetToken,
+      widgetsWithNewAPI,
+    );
   }
 
   get alertsConfig() {


### PR DESCRIPTION
* Incremental rollout check for `core--widgets-v2--chat-box` that should indicate whether the user has access to the new ChatBox features.
* Conditional logic on the widget system to use new widget APIs when `useNewWidgetConfig` is set to true.
* Simplest way of integrating the new API by patch the response and requests to the `global` object.
* One setting to test at the beginning, "Enable Chat Notifications", which triggers an alert when there's a new chat message.
* Few hacks, this is experimental and should be generalized.