### PR TITLE
fix(widgets): custom code in widgets have no defaults so they break

### DIFF
--- a/app/services/widgets/settings/widget-settings.ts
+++ b/app/services/widgets/settings/widget-settings.ts
@@ -11,6 +11,7 @@ import {
   IWidgetSettingsServiceApi,
   IWidgetSettingsState,
   TWIdgetLoadingState,
+  WidgetDefinitions,
   WidgetsService,
 } from 'services/widgets';
 import { Subject } from 'rxjs';
@@ -23,6 +24,7 @@ export const WIDGET_INITIAL_STATE: IWidgetSettingsGenericState = {
   data: null,
   rawData: null,
   pendingRequests: 0,
+  staticConfig: null,
 };
 
 export type THttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
@@ -98,12 +100,26 @@ export abstract class WidgetSettingsService<TWidgetData extends IWidgetData>
     const isFirstLoading = !this.state.data;
     if (isFirstLoading) this.SET_LOADING_STATE('pending');
     const apiSettings = this.getApiSettings();
+    // TODO: this is bad
     let rawData: any;
     try {
-      rawData = await this.request({
-        url: apiSettings.dataFetchUrl,
-        method: 'GET',
-      });
+      const widgetType = WidgetDefinitions[apiSettings.type].humanType;
+      const [widgetData, staticConfig] = await Promise.all([
+        this.request({
+          url: apiSettings.dataFetchUrl,
+          method: 'GET',
+        }),
+        // Only fetch this once
+        this.state.staticConfig
+          ? Promise.resolve(this.state.staticConfig)
+          : this.request({
+              url: `https://${this.hostsService.streamlabs}/api/v5/widgets/static/config/${widgetType}`,
+              method: 'GET',
+            }),
+      ]);
+      // TODO: see above
+      rawData = widgetData;
+      this.SET_WIDGET_STATIC_CONFIG(staticConfig);
     } catch (e: unknown) {
       if (isFirstLoading) this.SET_LOADING_STATE('fail');
       throw e;
@@ -122,8 +138,21 @@ export abstract class WidgetSettingsService<TWidgetData extends IWidgetData>
   protected handleDataAfterFetch(rawData: any): TWidgetData {
     const data = cloneDeep(rawData);
 
-    // patch fetched data to have the same data format
-    if (data.custom) data.custom_defaults = data.custom;
+    // TODO: type
+    const { staticConfig }: any = this.state;
+    if (staticConfig) {
+      // These seem only used to restore defaults
+      data.custom_defaults = staticConfig.data?.custom_code;
+      // If we have a default for custom code and the fields are empty in the
+      // response, prefill that with the default, this is what backend should
+      // also do
+      ['html', 'css', 'js'].forEach(customType => {
+        const prop = `custom_${customType}`;
+        if (staticConfig.data.custom_code[customType] && !data.settings[prop]) {
+          data.settings[prop] = staticConfig.data.custom_code[customType];
+        }
+      });
+    }
 
     data.type = this.getApiSettings().type;
 
@@ -204,6 +233,13 @@ export abstract class WidgetSettingsService<TWidgetData extends IWidgetData>
   protected SET_WIDGET_DATA(data: TWidgetData, rawData: any) {
     this.state.data = data;
     this.state.rawData = rawData;
+  }
+
+  @mutation()
+  // TODO: `unknown` because this needs to be generic and I don't wanna mess with that
+  // while custom code is broken
+  protected SET_WIDGET_STATIC_CONFIG(data: unknown) {
+    this.state.staticConfig = data;
   }
 
   @mutation()

--- a/app/services/widgets/widgets-api.ts
+++ b/app/services/widgets/widgets-api.ts
@@ -40,6 +40,12 @@ export interface IWidget {
 
   // An anchor (origin) point can be specified for the x&y positions
   anchor: AnchorPoint;
+
+  /**
+   * The actual type of the widget in string form, not a number.
+   * We use this to fetch the widget's static config.
+   */
+  humanType: string;
 }
 
 export interface IWidgetApiSettings {
@@ -106,6 +112,8 @@ export interface IWidgetSettingsGenericState {
   data: IWidgetData;
   rawData: Dictionary<any>; // widget data before patching
   pendingRequests: number; // amount of pending requests to the widget API
+  /** Widget static config (/api/v5/widgets/static/config/{widgetType} response **/
+  staticConfig: unknown;
 }
 
 export interface IWidgetSettingsState<TWidgetData extends IWidgetData>

--- a/app/services/widgets/widgets-data.ts
+++ b/app/services/widgets/widgets-data.ts
@@ -145,6 +145,7 @@ export const makeWidgetTesters = (host: string): IWidgetTester[] => {
 export const WidgetDefinitions: { [x: number]: IWidget } = {
   [WidgetType.AlertBox]: {
     name: 'Alert Box',
+    humanType: 'alert_box',
     url(host, token) {
       return `https://${host}/alert-box/v3/${token}`;
     },
@@ -160,6 +161,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
 
   [WidgetType.DonationGoal]: {
     name: 'Tip Goal',
+    humanType: 'donation_goal',
     url(host, token) {
       return `https://${host}/widgets/donation-goal?token=${token}`;
     },
@@ -175,6 +177,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
 
   [WidgetType.FollowerGoal]: {
     name: 'Follower Goal',
+    humanType: 'follower_goal',
     url(host, token) {
       return `https://${host}/widgets/follower-goal?token=${token}`;
     },
@@ -188,8 +191,10 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
     anchor: AnchorPoint.SouthWest,
   },
 
+  // TODO: what is this widget and why does it point to follower goal?
   [WidgetType.SubscriberGoal]: {
     name: 'Subscriber Goal',
+    humanType: 'follower_goal',
     url(host, token) {
       return `https://${host}/widgets/follower-goal?token=${token}`;
     },
@@ -205,6 +210,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
 
   [WidgetType.SubGoal]: {
     name: 'Sub Goal',
+    humanType: 'sub_goal',
     url(host, token) {
       return `https://${host}/widgets/sub-goal?token=${token}`;
     },
@@ -220,6 +226,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
 
   [WidgetType.BitGoal]: {
     name: 'Bit Goal',
+    humanType: 'bit_goal',
     url(host, token) {
       return `https://${host}/widgets/bit-goal?token=${token}`;
     },
@@ -235,6 +242,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
 
   [WidgetType.StarsGoal]: {
     name: 'Stars Goal',
+    humanType: 'stars_goal',
     url(host, token) {
       return `https://${host}/widgets/stars-goal?token=${token}`;
     },
@@ -250,6 +258,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
 
   [WidgetType.SupporterGoal]: {
     name: 'Supporter Goal',
+    humanType: 'supporter_goal',
     url(host, token) {
       return `https://${host}/widgets/supporter-goal?token=${token}`;
     },
@@ -265,6 +274,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
 
   [WidgetType.SuperchatGoal]: {
     name: 'Superchat Goal',
+    humanType: 'super_chat_goal',
     url(host, token) {
       return `https://${host}/widgets/super-chat-goal?token=${token}`;
     },
@@ -280,6 +290,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
 
   [WidgetType.CharityGoal]: {
     name: 'Streamlabs Charity Goal',
+    humanType: 'streamlabs_charity_donation_goal',
     url(host, token) {
       return `https://${host}/widgets/streamlabs-charity-donation-goal?token=${token}`;
     },
@@ -295,6 +306,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
 
   [WidgetType.DonationTicker]: {
     name: 'Donation Ticker',
+    humanType: 'donation_ticker',
     url(host, token) {
       return `https://${host}/widgets/donation-ticker?token=${token}`;
     },
@@ -310,6 +322,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
 
   [WidgetType.ChatBox]: {
     name: 'Chat Box',
+    humanType: 'chat_box',
     url(host, token) {
       return `https://${host}/widgets/chat-box/v1/${token}`;
     },
@@ -325,6 +338,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
 
   [WidgetType.EventList]: {
     name: 'Event List',
+    humanType: 'event_list',
     url(host, token) {
       return `https://${host}/widgets/event-list/v1/${token}`;
     },
@@ -340,6 +354,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
 
   [WidgetType.TipJar]: {
     name: 'The Jar',
+    humanType: 'tip_jar',
     url(host, token) {
       return `https://${host}/widgets/tip-jar/v1/${token}`;
     },
@@ -355,6 +370,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
 
   [WidgetType.StreamBoss]: {
     name: 'Stream Boss',
+    humanType: 'stream_boss',
     url(host, token) {
       return `https://${host}/widgets/streamboss?token=${token}`;
     },
@@ -370,6 +386,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
 
   [WidgetType.Credits]: {
     name: 'Credits',
+    humanType: 'end_credits',
     url(host, token) {
       return `https://${host}/widgets/end-credits?token=${token}`;
     },
@@ -385,6 +402,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
 
   [WidgetType.SponsorBanner]: {
     name: 'Sponsor Banner',
+    humanType: 'sponsor_banner',
     url(host, token) {
       return `https://${host}/widgets/sponsor-banner?token=${token}`;
     },
@@ -399,6 +417,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
   },
 
   [WidgetType.SpinWheel]: {
+    humanType: 'wheel',
     name: 'Spin Wheel',
     url(host, token) {
       return `https://${host}/widgets/wheel?token=${token}`;
@@ -415,6 +434,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
 
   [WidgetType.MediaShare]: {
     name: 'Media Share',
+    humanType: 'media-sharing',
     url(host, token) {
       return `https://${host}/widgets/media/v1/${token}`;
     },
@@ -429,6 +449,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
   },
   [WidgetType.Poll]: {
     name: 'Poll',
+    humanType: 'poll',
     url(host, token) {
       return `https://${host}/widgets/poll/${token}`;
     },
@@ -443,6 +464,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
   },
   [WidgetType.EmoteWall]: {
     name: 'Emote Wall',
+    humanType: 'emote-wall',
     url(host, token) {
       return `https://${host}/widgets/emote-wall?token=${token}`;
     },
@@ -457,6 +479,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
   },
   [WidgetType.ChatHighlight]: {
     name: 'Chat Highlight',
+    humanType: 'chat_highlight',
     url(host, token) {
       return `https://${host}/widgets/chat-highlight?token=${token}`;
     },


### PR DESCRIPTION
Widgets can get into an invalid state when enabling custom code, no defaults were consistently provided by backend and, as a result, enabling the Custom Code option could result in empty widget HTML, CSS and JS, thus breaking the widget.
In some cases, users could recover by going through the dashboard and choosing to "Reset Defaults", but this change makes that invalid state impossible.
We fetch custom code defaults through the new static config API at `/api/v5/widgets/static/config/{widgetType}` and populate those fields if they're empty on widget settings load. 
We needed to add a new `humanType` field which is the widget type in string representation as opposed to the number enum so we can pass it to that endpoint.
Also updates the `custom_defaults` property that is supposed to be used to provide that reset functionality on Desktop, though is inconsistent where we've seen this button be available.
Backend is working towards a complete fix which will return the default code in the standard settings endpoints if they're empty to make sure it never breaks again, and also that users can't end up in invalid state by resetting them through the web UI. 
