### PR TITLE
fix(widgets): infinite loading in widget settings

### DIFF
--- a/app/services/widgets/widget-source.ts
+++ b/app/services/widgets/widget-source.ts
@@ -74,7 +74,7 @@ export class WidgetSource implements IWidgetSource {
 
   destroyPreviewSource() {
     this.widgetsService.stopSyncPreviewSource(this.previewSourceId);
-    this.sourcesService.views.getSource(this.previewSourceId).remove();
+    this.sourcesService.views.getSource(this.previewSourceId)?.remove();
     this.SET_PREVIEW_SOURCE_ID('');
   }
 

--- a/app/services/widgets/widgets.ts
+++ b/app/services/widgets/widgets.ts
@@ -254,6 +254,14 @@ export class WidgetsService
   }
 
   stopSyncPreviewSource(previewSourceId: string) {
+    if (!this.previewSourceWatchers[previewSourceId]) {
+      console.warn(
+        'Trying to destroy preview source',
+        previewSourceId,
+        'which is not on the watcher list, perhaps called twice?',
+      );
+      return;
+    }
     this.previewSourceWatchers[previewSourceId].unsubscribe();
     delete this.previewSourceWatchers[previewSourceId];
   }


### PR DESCRIPTION
Infinite loading on widget settings could happen by doing by following:

1. Opening a React widget settings page
2. Opening the custom code window from within that page.
3. Closing the custom code window.

After the custom code window closes, the widget settings are unable to load again
until the app is restarted.

This is caused by a combination of using the `beforeunload` handler, without taking
into account window IDs (and custom code editor is a one-off window) to execute
code conditionally, (this handler might be called for *any* window closing,
need to confirm due to the weird behavior following) and the fact that the
`WidgetModule`'s code is run again in that window (presumably because
of the `injectChild` call it uses). This is particularly relevant with the `init`
method which registers preview source, said handler, fetches data, and more.

As a result, we ended up registering two handlers that tried to cleanup the
widget preview source, with the second one (the widget settings if you closed
the custom code window first) unable to succeed. We were also attempting to
create that preview source on the custom code one-off window, which is
unnecessary and might've contributed to the issue, since only one preview
source per widget is allowed, and the code throws if we try to.

Also indirectly fixed is the `destroy` method of such module, while `cancelUnload` might
trigger without a `destroy` (if I understand correctly for window refresh in
development mode), calling both at once with only one having a null-check might
throw, and that is exactly what `destroy` did. The fact this code is ran as the
window was closing might've obscured that this could happen.