### PR TITLE
fix(settings): external merge causes settings window invalid state

### DIFF
--- a/app/components-react/windows/settings/Stream.tsx
+++ b/app/components-react/windows/settings/Stream.tsx
@@ -39,18 +39,27 @@ function censorEmail(str: string) {
  */
 class StreamSettingsModule {
   constructor() {
+    const showMessage = (msg: string, success: boolean) => {
+      message.config({
+        duration: 6,
+        maxCount: 1,
+      });
+
+      if (success) {
+        message.success(msg);
+      } else {
+        message.error(msg);
+      }
+    };
     Services.UserService.refreshedLinkedAccounts.subscribe(
       (res: { success: boolean; message: string }) => {
-        message.config({
-          duration: 6,
-          maxCount: 1,
-        });
-
-        if (res.success) {
-          message.success(res.message);
-        } else {
-          message.error(res.message);
-        }
+        const doShowMessage = () => showMessage(res.message, res.success);
+        /*
+         * Since the settings window pops out anyways (presumably because of
+         * using `message`make sure it is at least on the right page, as opposed
+         * to in an infinite loading blank window state.
+         */
+        doShowMessage();
       },
     );
   }

--- a/app/components/windows/settings/Settings.vue.ts
+++ b/app/components/windows/settings/Settings.vue.ts
@@ -173,10 +173,16 @@ export default class Settings extends Vue {
   }
 
   getInitialCategoryName() {
-    if (this.windowsService.state.child.queryParams) {
-      return this.windowsService.state.child.queryParams.categoryName || 'General';
-    }
-    return 'General';
+    /* Some sort of race condition, perhaps `WindowsService` creating
+     * the window, and *only* after updating its options, results in
+     * accessing state here to be empty for `state.child.queryParams`
+     * which is what this method used to use, unless the child window
+     * has already been displayed once?
+     *
+     * Switching to this method call seems to solve the issue, plus we
+     * shouldn't be accessing state directly regardless.
+     */
+    return this.windowsService.getChildWindowQueryParams()?.categoryName ?? 'General';
   }
 
   get categoryNames() {

--- a/app/services/user/index.ts
+++ b/app/services/user/index.ts
@@ -464,11 +464,14 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
             ? $t('Successfully merged account')
             : $t('Successfully unlinked account');
 
+        await this.showStreamSettingsIfNeeded();
+
         this.windowsService.actions.setWindowOnTop('all');
         this.refreshedLinkedAccounts.next({ success: true, message });
       }
 
       if (event.type === 'account_merge_error') {
+        await this.showStreamSettingsIfNeeded();
         this.windowsService.actions.setWindowOnTop('all');
         this.refreshedLinkedAccounts.next({ success: false, message: $t('Account merge error') });
       }
@@ -482,6 +485,31 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
         await this.startChatAuth(platform as TPlatform);
       }
     });
+  }
+
+  /*
+   * Since we're displaying the child window in all cases, it might've
+   * been closed when we get this event, so no component was rendered into
+   * it and instead shows an empty blank window with a loading spinner.
+   * It could also never been created (or a component rendered into it
+   * at least), both cases resulted in that invalid state.
+   *
+   * If the child window is closed, and we get one of these user events,
+   * (refer to callers), show Settings -> Stream which in our case should
+   * displays user accounts.
+   */
+  async showStreamSettingsIfNeeded() {
+    if (this.windowsService.state.child && !this.windowsService.state.child.isShown) {
+      this.settingsService.showSettings('Stream');
+      /* TODO: added a sleep here so on first child window create
+       * we still get to see messages (i.e Stream settings).
+       * Otherwise subscriber is called late, since this is a normal
+       * subject.
+       * TODO: should we convert to `BehaviorSubject` or whatever was
+       * it the one that replays events for new subscribers?
+       */
+      await Utils.sleep(500);
+    }
   }
 
   get views() {


### PR DESCRIPTION
ref: https://app.asana.com/0/1207748235152481/1208799194156887/f

When performing an external link/unlink action through the Dashboard with SL Desktop opened, the Settings window pops out blank and with a spinner which never finishes.

This happens because we still get that socket event, and we still attempt to focus and show all windows. Child window can easily get into a state where it hasn't rendered anything before, or it's just not open when this happens. We then just attempt to show this window with nothing in it.

This fix should show the Stream section of the Settings page when these events happen, taking care of some race conditions around this entire area as well.