### PR TITLE
feat(streaming): expand viewer count clickable area, add hover cursor

### DIFF
--- a/app/components-react/root/LiveDock.m.less
+++ b/app/components-react/root/LiveDock.m.less
@@ -123,6 +123,8 @@
   }
 
   &:hover {
+    cursor: pointer;
+
     .live-dock-viewer-count-toggle {
       opacity: 1;
     }

--- a/app/components-react/root/LiveDock.tsx
+++ b/app/components-react/root/LiveDock.tsx
@@ -395,13 +395,12 @@ function LiveDock(p: { onLeft: boolean }) {
                 <span className={styles.liveDockText}>{liveText}</span>
                 <span className={styles.liveDockTimer}>{elapsedStreamTime}</span>
               </div>
-              <div className={styles.liveDockViewerCount}>
+              <div className={styles.liveDockViewerCount} onClick={() => ctrl.toggleViewerCount()}>
                 <i
                   className={cx({
                     ['icon-view']: !hideViewerCount,
                     ['icon-hide']: hideViewerCount,
                   })}
-                  onClick={() => ctrl.toggleViewerCount()}
                 />
                 <span className={styles.liveDockViewerCountCount}>{viewerCount}</span>
                 {Number(viewerCount) >= 0 && <span>{$t('viewers')}</span>}


### PR DESCRIPTION
ref: https://app.asana.com/0/1207748235152481/1208760218589708/f

Expand viewer count's clickable area on the dock to include text as well, previously only the icon was clickable for the toggle behavior. Also add a hover cursor to suggest it's interactive. 