### PR TITLE
fix(widgets): stream boss fails to load settings

### DIFF
--- a/app/services/widgets/widgets-data.ts
+++ b/app/services/widgets/widgets-data.ts
@@ -371,7 +371,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
 
   [WidgetType.StreamBoss]: {
     name: 'Stream Boss',
-    humanType: 'stream_boss',
+    humanType: 'streamboss',
     url(host, token) {
       return `https://${host}/widgets/streamboss?token=${token}`;
     },


### PR DESCRIPTION
ref: https://app.asana.com/0/1207748235152481/1208811601171674/f

Stream Boss widget fails to load settings due to incorrect static config endpoint. 