### PR TITLE
feat: shareable stream links

### DIFF
--- a/app/components-react/root/LiveDock.tsx
+++ b/app/components-react/root/LiveDock.tsx
@@ -18,6 +18,7 @@ import { useVuex } from 'components-react/hooks';
 import { useRealmObject } from 'components-react/hooks/realm';
 import { $i } from 'services/utils';
 import { TikTokChatInfo } from './TiktokChatInfo';
+import { ShareStreamLink } from './ShareStreamLink';
 
 const LiveDockCtx = React.createContext<LiveDockController | null>(null);
 
@@ -427,6 +428,7 @@ function LiveDock(p: { onLeft: boolean }) {
                     <i onClick={() => ctrl.openPlatformStream()} className="icon-studio" />
                   </Tooltip>
                 )}
+                {isStreaming && <ShareStreamLink />}
                 {isPlatform(['youtube', 'facebook', 'tiktok']) && isStreaming && (
                   <Tooltip
                     title={$t('Go to Live Dashboard')}

--- a/app/components-react/root/ShareStreamLink.m.less
+++ b/app/components-react/root/ShareStreamLink.m.less
@@ -1,0 +1,15 @@
+.shareStreamLinksContainer {
+  display: flex;
+  margin-top: -5px;
+
+  :global(i.youtube) {
+    width: 20px;
+    height: 20px;
+    margin-top: 6px;
+  }
+
+  :global(i.tiktok) {
+    width: 16px;
+    height: 16px;
+  }
+}

--- a/app/components-react/root/ShareStreamLink.tsx
+++ b/app/components-react/root/ShareStreamLink.tsx
@@ -38,7 +38,7 @@ export const ShareStreamLink = () => {
     });
 
     return (
-      <Tooltip key={platform} placement="right" title={tooltip}>
+      <Tooltip key={platform} placement="right" title={tooltip} autoAdjustOverflow={false}>
         <Button
           type="text"
           title={tooltip}

--- a/app/components-react/root/ShareStreamLink.tsx
+++ b/app/components-react/root/ShareStreamLink.tsx
@@ -7,6 +7,7 @@ import { Button, message } from 'antd';
 import { CloseOutlined, ShareAltOutlined } from '@ant-design/icons';
 import PlatformLogo from 'components-react/shared/PlatformLogo';
 import Tooltip from 'components-react/shared/Tooltip';
+import styles from './ShareStreamLink.m.less';
 
 /*
  * There's a weird issue on the Live Dock where components placed above
@@ -52,7 +53,7 @@ export const ShareStreamLink = () => {
   const single = items.length < 2;
 
   return (
-    <div style={{ marginTop: -5, display: 'flex' }}>
+    <div className={styles.shareStreamLinksContainer}>
       {single ? (
         <Tooltip placement="right" title={$t('Copy stream link')}>
           <Button

--- a/app/components-react/root/ShareStreamLink.tsx
+++ b/app/components-react/root/ShareStreamLink.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import { Services } from '../service-provider';
+import { $t } from 'services/i18n';
+import { clipboard } from 'electron';
+import { getPlatformService } from 'services/platforms';
+import { Button, message } from 'antd';
+import { CloseOutlined, ShareAltOutlined } from '@ant-design/icons';
+import PlatformLogo from 'components-react/shared/PlatformLogo';
+import Tooltip from 'components-react/shared/Tooltip';
+
+/*
+ * There's a weird issue on the Live Dock where components placed above
+ * chat can't overlap (even if overlaid) on top of that section.
+ * As a result, our choice of components in this area is quite limited,
+ * for example, dropdowns are cut off.
+ * Would love to use a FloatButton with a right placement for this
+ * (https://ant.design/components/float-button#float-button-demo-placement)
+ * but is not included in our version of Antd. Backporting is also not feasible
+ * due to 5.x using CSS in JS among other breaking changes.
+ * As such, we're left with a Radio Group.
+ */
+export const ShareStreamLink = () => {
+  const [expanded, setExpanded] = useState(false);
+
+  const toggleExpanded = () => setExpanded(expanded => !expanded);
+  const { StreamingService } = Services;
+
+  const items = StreamingService.views.enabledPlatforms.map(platform => {
+    const service = getPlatformService(platform);
+    const streamPageUrl = service.streamPageUrl;
+
+    if (!streamPageUrl) {
+      return;
+    }
+
+    const tooltip = $t('Copy %{platform} link', {
+      platform: StreamingService.views.getPlatformDisplayName(platform),
+    });
+
+    return (
+      <Tooltip key={platform} placement="right" title={tooltip}>
+        <Button
+          type="text"
+          title={tooltip}
+          onClick={() => copyToClipboard(streamPageUrl)}
+          icon={<PlatformLogo platform={platform} />}
+        />
+      </Tooltip>
+    );
+  });
+
+  const single = items.length < 2;
+
+  return (
+    <div style={{ marginTop: -5, display: 'flex' }}>
+      {single ? (
+        <Tooltip placement="right" title={$t('Copy stream link')}>
+          <Button
+            type="text"
+            icon={<ShareAltOutlined />}
+            title={$t('Copy stream link')}
+            onClick={() =>
+              copyToClipboard(
+                getPlatformService(StreamingService.views.enabledPlatforms[0]).streamPageUrl,
+              )
+            }
+          />
+        </Tooltip>
+      ) : (
+        <>
+          <Tooltip placement="right" title={$t('Share stream link')}>
+            <Button
+              type="text"
+              icon={expanded ? <CloseOutlined /> : <ShareAltOutlined />}
+              title={$t('Share stream link')}
+              onClick={() => toggleExpanded()}
+            />
+          </Tooltip>
+          <div
+            style={{
+              flex: 1,
+              display: expanded ? 'flex' : 'none',
+              justifyContent: 'space-between',
+              transition: 'all 1s ease-in-out',
+            }}
+          >
+            {items}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+const copyToClipboard = (link: string) => {
+  clipboard.writeText(link);
+  message.open({
+    type: 'success',
+    content: $t('Copied to clipboard'),
+    duration: 2,
+    /* Since there's no easy way to get this off the footer (yes, we tried
+     * `getContainer`), style a bit so it doesn't get cut off
+     */
+    style: {
+      padding: 0,
+      marginTop: '-5px',
+    },
+  });
+};

--- a/app/components-react/root/ShareStreamLink.tsx
+++ b/app/components-react/root/ShareStreamLink.tsx
@@ -42,7 +42,7 @@ export const ShareStreamLink = () => {
       <Tooltip key={platform} placement="right" title={tooltip} autoAdjustOverflow={false}>
         <Button
           type="text"
-          title={tooltip}
+          aria-label={tooltip}
           onClick={() => copyToClipboard(streamPageUrl)}
           icon={<PlatformLogo platform={platform} />}
         />
@@ -59,7 +59,7 @@ export const ShareStreamLink = () => {
           <Button
             type="text"
             icon={<ShareAltOutlined />}
-            title={$t('Copy stream link')}
+            aria-label={$t('Copy stream link')}
             onClick={() =>
               copyToClipboard(
                 getPlatformService(StreamingService.views.enabledPlatforms[0]).streamPageUrl,
@@ -73,7 +73,7 @@ export const ShareStreamLink = () => {
             <Button
               type="text"
               icon={expanded ? <CloseOutlined /> : <ShareAltOutlined />}
-              title={$t('Share stream link')}
+              aria-label={$t('Share stream link')}
               onClick={() => toggleExpanded()}
             />
           </Tooltip>

--- a/app/i18n/en-US/streaming.json
+++ b/app/i18n/en-US/streaming.json
@@ -275,5 +275,9 @@
   "Detect CPU usage in Dual Output mode": "Detect CPU usage in Dual Output mode",
   "High CPU Usage: %{percentage}% used": "High CPU Usage: %{percentage}% used",
   "High CPU Usage: Detected": "High CPU Usage: Detected",
-  "TikTok Audience": "TikTok Audience"
+  "TikTok Audience": "TikTok Audience",
+  "Share stream link": "Share stream link",
+  "Copy stream link": "Copy stream link",
+  "Copy %{platform} link": "Copy %{platform} link",
+  "Copied to clipboard": "Copied to clipboard"
 }


### PR DESCRIPTION
ref: https://app.asana.com/0/1207748309288779/1208799194156876/f

Add a new share stream button to the Live Dock that allows user to copy the stream URL. When using multiple platforms, the button expands into a section to copy the link for each individual platform.
