### PR TITLE
fix(dual-output): disable extra platforms when needed after mode switch

### DIFF
--- a/app/components-react/windows/go-live/DestinationSwitchers.tsx
+++ b/app/components-react/windows/go-live/DestinationSwitchers.tsx
@@ -87,6 +87,7 @@ export function DestinationSwitchers(p: { showSelector?: boolean }) {
            * If we had two platforms, none of which were tiktok, we still need to limit
            * that to 1 platform without restreaming.
            * This could happen when coming from having dual output enabled to off.
+           *  TODO: this might not be needed after #5244, keeping here for a while for extra care
            */
           enabledPlatformsRef.current = enabledPlatformsRef.current.slice(0, 1);
         } else {

--- a/app/services/dual-output/dual-output.ts
+++ b/app/services/dual-output/dual-output.ts
@@ -291,9 +291,6 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
   @Inject() private selectionService: SelectionService;
   @Inject() private streamingService: StreamingService;
   @Inject() private settingsService: SettingsService;
-  @Inject() private sourcesService: SourcesService;
-  @Inject() private widgetsService: WidgetsService;
-  @Inject() private defaultHardwareService: DefaultHardwareService;
 
   static defaultState: IDualOutputServiceState = {
     dualOutputMode: false,


### PR DESCRIPTION
ref: https://app.asana.com/0/1207748235152481/1208813184366087/f

Follow-up to #5239 which addresses the invalid state after the TikTok toggle specifically is clicked, this one should prevent it completely by disabling extra platforms when needed on Go Live's `prepopulate`.

Also removes unused service injects.