### PR TITLE
Fix for collectibles duplicated in vertical display.

### DIFF
--- a/app/components-react/pages/BrowseOverlays.tsx
+++ b/app/components-react/pages/BrowseOverlays.tsx
@@ -172,7 +172,9 @@ export default function BrowseOverlays(p: {
     }
 
     const sourceSettings =
-      type === 'video' ? { looping: true, local_file: localFile } : { file: localFile };
+      type === 'video'
+        ? { looping: true, local_file: localFile, display: 'horizontal' }
+        : { file: localFile, display: 'horizontal' };
 
     return ScenesService.actions.return.createAndAddSource(
       sceneId,

--- a/app/services/scenes/scenes.ts
+++ b/app/services/scenes/scenes.ts
@@ -460,28 +460,12 @@ export class ScenesService extends StatefulService<IScenesState> {
 
     const sceneItem = scene.createAndAddSource(sourceName, sourceType, settings);
 
-    const createVerticalNode = () => {
+    if (this.dualOutputService.views.hasSceneNodeMaps) {
       this.dualOutputService.createPartnerNode(sceneItem);
       /* For some reason dragging items after enabling dual output makes them
        * duplicate, associate selection on switch to mitigate this issue
        */
       this.selectionService.associateSelectionWithDisplay('vertical');
-    };
-
-    if (this.dualOutputService.state.dualOutputMode) {
-      createVerticalNode();
-    } else {
-      // Schedule vertical node to be created if the user toggles on dual output in the same session
-      this.dualOutputService.dualOutputModeChanged
-        .pipe(
-          // If we switch collections before we enable dual output drop it
-          // we don't wanna create nodes on inactive scene collections
-          takeUntil(this.sceneCollectionsService.collectionWillSwitch),
-          filter(gotEnabled => !!gotEnabled),
-          take(1),
-          tap(createVerticalNode),
-        )
-        .subscribe();
     }
 
     return sceneItem.sceneItemId;


### PR DESCRIPTION
Associate collectibles with horizontal display on creation and check for node map so that the dual output collection creates the vertical sources without duplication.