### PR TITLE
Fixed audio bars positioning for GL volmeters

### DIFF
--- a/app/components-react/editor/elements/mixer/GLVolmeters.tsx
+++ b/app/components-react/editor/elements/mixer/GLVolmeters.tsx
@@ -11,8 +11,9 @@ import { assertIsDefined, getDefined } from 'util/properties-type-guards';
 // Configuration
 const CHANNEL_HEIGHT = 3;
 const SPACE_BETWEEN_CHANNELS = 2;
+// When height of audio mixer elements changes, these paddings values also should be updated
 const PADDING_TOP = 39;
-const PADDING_BOTTOM = 49;
+const PADDING_BOTTOM = 57;
 const PEAK_WIDTH = 4;
 const PEAK_HOLD_CYCLES = 100;
 const WARNING_LEVEL = -20;
@@ -375,11 +376,7 @@ class GLVolmetersController {
       offsetTop += PADDING_TOP;
       const volmeter = this.subscriptions[sourceId];
       this.drawVolmeterWebgl(volmeter, offsetTop);
-
-      offsetTop +=
-        CHANNEL_HEIGHT * volmeter.channelsCount +
-        SPACE_BETWEEN_CHANNELS * (volmeter.channelsCount - 1) +
-        PADDING_BOTTOM;
+      offsetTop += PADDING_BOTTOM;
     });
   }
 


### PR DESCRIPTION
Fix of the long-standing issue related to audio bars positioning.
Steps to reproduce:
- Find a video with a single audio channel
- Add it multiple times (you can probably clone the file, if you want)
- For better results add video with double audio channels to the bottom
- Observe results

![image](https://github.com/user-attachments/assets/b49f1360-a0ec-4d99-a671-97fccd8804d1)
