### PR TITLE
Replace missing configured audio input device with the default.

### DIFF
--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -444,8 +444,14 @@ export class SourcesService extends StatefulService<ISourcesState> {
         const deviceOption = (deviceProp as IObsListInput<string>).options.find(
           opt => opt.value === deviceProp.value,
         );
-
-        if (deviceOption) {
+        if (!deviceOption) {
+          const updateSettings = source.getSettings();
+          updateSettings['device_id'] = 'default';
+          source.updateSettings(updateSettings);
+          this.usageStatisticsService.recordAnalyticsEvent('MicrophoneUse', {
+            device: 'Default',
+          });
+        } else {
           this.usageStatisticsService.recordAnalyticsEvent('MicrophoneUse', {
             device: deviceOption.description,
           });


### PR DESCRIPTION
If an audio input capture source is configured with a device that becomes unavailable, replace it with the default audio input device when loading sources.